### PR TITLE
MAKE-655: Gimlet PPROF routes invalid

### DIFF
--- a/app_merge.go
+++ b/app_merge.go
@@ -102,7 +102,7 @@ func (a *APIApp) Merge(apps ...*APIApp) error {
 			seenPrefixes[app.prefix] = struct{}{}
 
 			for _, route := range app.routes {
-				r := a.PrefixRoute(app.prefix).Route(route.route).Version(route.version)
+				r := a.PrefixRoute(app.prefix).Route(route.route).Version(route.version).Handler(route.handler)
 				for _, m := range route.methods {
 					r = r.Method(m.String())
 				}

--- a/pprof.go
+++ b/pprof.go
@@ -26,16 +26,16 @@ func GetPProfApp() *APIApp {
 	app.SetPrefix("/debug/pprof")
 	app.NoVersions = true
 
-	app.AddRoute("/").Get().Handler(pprofIndex)
-	app.AddRoute("/heap").Get().Handler(pprofIndex)
-	app.AddRoute("/block").Get().Handler(pprofIndex)
-	app.AddRoute("/goroutine").Get().Handler(pprofIndex)
-	app.AddRoute("/mutex").Get().Handler(pprofIndex)
-	app.AddRoute("/threadcreate").Get().Handler(pprofIndex)
-	app.AddRoute("/cmdline").Get().Handler(pprofCmdline)
-	app.AddRoute("/profile").Get().Handler(pprofProfile)
-	app.AddRoute("/symbol").Get().Handler(pprofSymbol)
-	app.AddRoute("/trace").Get().Handler(pprofTrace)
+	app.AddRoute("/").Version(1).Get().Handler(pprofIndex)
+	app.AddRoute("/heap").Version(1).Get().Handler(pprofIndex)
+	app.AddRoute("/block").Version(1).Get().Handler(pprofIndex)
+	app.AddRoute("/goroutine").Version(1).Get().Handler(pprofIndex)
+	app.AddRoute("/mutex").Version(1).Get().Handler(pprofIndex)
+	app.AddRoute("/threadcreate").Version(1).Get().Handler(pprofIndex)
+	app.AddRoute("/cmdline").Version(1).Get().Handler(pprofCmdline)
+	app.AddRoute("/profile").Version(1).Get().Handler(pprofProfile)
+	app.AddRoute("/symbol").Version(1).Get().Handler(pprofSymbol)
+	app.AddRoute("/trace").Version(1).Get().Handler(pprofTrace)
 
 	return app
 }


### PR DESCRIPTION
This is causing test failures in cedar. I made the fixes in cedar's vendored gimlet and the service ran successfully with cert generation tests passing. I think we may want to add more tests for the app merge function (since the current tests did not catch this bug). Once this bug is fixed, cedar will need a revendor to get tests passing.