### PR TITLE
EVG-5785: Return an empty array for no data

### DIFF
--- a/framework_response.go
+++ b/framework_response.go
@@ -74,6 +74,7 @@ func NewResponseBuilder() Responder {
 	return &responseBuilder{
 		status: http.StatusOK,
 		format: JSON,
+		data:   make([]interface{}, 0),
 	}
 }
 
@@ -110,7 +111,7 @@ func (r *responseBuilder) Pages() *ResponsePages { return r.pages }
 
 func (r *responseBuilder) AddData(d interface{}) error {
 	if d == nil {
-		return errors.New("cannot  data to responder")
+		return errors.New("cannot add nil data to responder")
 	}
 
 	r.data = append(r.data, d)

--- a/framework_response.go
+++ b/framework_response.go
@@ -74,7 +74,7 @@ func NewResponseBuilder() Responder {
 	return &responseBuilder{
 		status: http.StatusOK,
 		format: JSON,
-		data:   make([]interface{}, 0),
+		data:   []interface{}{},
 	}
 }
 


### PR DESCRIPTION
Previously would send down null if no data was ever added since the interface{} was never initialized.
Now sends an empty array.