### PR TITLE
EVG-6375 add permission registry

### DIFF
--- a/acl/roles.go
+++ b/acl/roles.go
@@ -10,15 +10,13 @@ import (
 )
 
 type updateRoleHandler struct {
-	manager      gimlet.RoleManager
-	role         *gimlet.Role
-	validateFunc func(gimlet.Role) error
+	manager gimlet.RoleManager
+	role    *gimlet.Role
 }
 
-func NewUpdateRoleHandler(m gimlet.RoleManager, validateFunc func(gimlet.Role) error) gimlet.RouteHandler {
+func NewUpdateRoleHandler(m gimlet.RoleManager) gimlet.RouteHandler {
 	return &updateRoleHandler{
-		manager:      m,
-		validateFunc: validateFunc,
+		manager: m,
 	}
 }
 
@@ -36,7 +34,7 @@ func (h *updateRoleHandler) Parse(ctx context.Context, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	return h.validateFunc(*h.role)
+	return nil
 }
 
 func (h *updateRoleHandler) Run(ctx context.Context) gimlet.Responder {

--- a/acl/roles_test.go
+++ b/acl/roles_test.go
@@ -25,19 +25,13 @@ func testRoleUpdate(t *testing.T, m gimlet.RoleManager) func(t *testing.T) {
 			"permissions": map[string]int{"p1": 1},
 			"owners":      []string{"me"},
 		}
-		var validateWasCalled bool
-		validate := func(gimlet.Role) error {
-			validateWasCalled = true
-			return nil
-		}
-		handler := NewUpdateRoleHandler(m, validate)
+		handler := NewUpdateRoleHandler(m)
 
 		jsonBody, err := json.Marshal(body)
 		assert.NoError(t, err)
 		buffer := bytes.NewBuffer(jsonBody)
 		request, err := http.NewRequest(http.MethodPost, "/roles", buffer)
 		assert.NoError(t, handler.Parse(context.Background(), request))
-		assert.True(t, validateWasCalled)
 		resp := handler.Run(context.Background())
 		assert.Equal(t, 200, resp.Status())
 	}

--- a/auth_interfaces.go
+++ b/auth_interfaces.go
@@ -85,6 +85,7 @@ type RoleManager interface {
 	// DeleteScope removes a scope from the manager
 	DeleteScope(string) error
 
-	// DeleteScope removes a scope from the manager
+	// RegisterPermissions adds a list of strings to the role manager as valid permission keys. Returns an
+	// error if the same permission is registered more than once
 	RegisterPermissions([]string) error
 }

--- a/auth_interfaces.go
+++ b/auth_interfaces.go
@@ -84,4 +84,7 @@ type RoleManager interface {
 
 	// DeleteScope removes a scope from the manager
 	DeleteScope(string) error
+
+	// DeleteScope removes a scope from the manager
+	RegisterPermissions([]string) error
 }

--- a/rolemanager/role_manager_test.go
+++ b/rolemanager/role_manager_test.go
@@ -79,6 +79,10 @@ func (s *RoleManagerSuite) SetupSuite() {
 		ID: "root",
 	}
 	s.NoError(s.m.AddScope(root))
+
+	permissions := []string{"edit", "read"}
+	s.NoError(s.m.RegisterPermissions(permissions))
+	s.Error(s.m.RegisterPermissions(permissions))
 }
 
 func (s *RoleManagerSuite) SetupTest() {


### PR DESCRIPTION
- create the concept of a permission registry, where valid permission keys are specified
- enforce that roles can't be created if they have an unregistered permission key
- fix an unrelated bug where inserting a new role returns a database error