### PR TITLE
EVG-6380 add method to find role with given permissions

### DIFF
--- a/auth_interfaces.go
+++ b/auth_interfaces.go
@@ -102,4 +102,8 @@ type RoleManager interface {
 	// RegisterPermissions adds a list of strings to the role manager as valid permission keys. Returns an
 	// error if the same permission is registered more than once
 	RegisterPermissions([]string) error
+
+	// FindRolesWithPermissions returns a role that exactly matches the given resources and permissions
+	// TODO: there should also be a method to create such a role
+	FindRoleWithPermissions([]string, Permissions) (*Role, error)
 }

--- a/auth_interfaces.go
+++ b/auth_interfaces.go
@@ -93,6 +93,9 @@ type RoleManager interface {
 	// type and returns a list of scopes filtered by the resource type.
 	FilterScopesByResourceType([]string, string) ([]Scope, error)
 
+	// FindScopeForResources returns a scope that exactly matches a given set of resources
+	FindScopeForResources(string, ...string) (*Scope, error)
+
 	// AddScope adds a scope to the manager
 	AddScope(Scope) error
 
@@ -104,6 +107,8 @@ type RoleManager interface {
 	RegisterPermissions([]string) error
 
 	// FindRolesWithPermissions returns a role that exactly matches the given resources and permissions
-	// TODO: there should also be a method to create such a role
-	FindRoleWithPermissions([]string, Permissions) (*Role, error)
+	FindRoleWithPermissions(string, []string, Permissions) (*Role, error)
+
+	// Clear deletes all roles and scopes. This should only be used in tests
+	Clear() error
 }

--- a/rolemanager/role_manager.go
+++ b/rolemanager/role_manager.go
@@ -165,19 +165,20 @@ func (m *mongoBackedRoleManager) FindScopeForResources(resourceType string, reso
 			}},
 		},
 	}
-	cursor, err := coll.Find(ctx, query)
+	result := coll.FindOne(ctx, query)
+	err := result.Err()
 	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
 		return nil, err
 	}
-	scopes := []gimlet.Scope{}
-	if err = cursor.All(ctx, &scopes); err != nil {
+	scope := &gimlet.Scope{}
+	if err := result.Decode(scope); err != nil {
 		return nil, err
-	}
-	if len(scopes) == 0 {
-		return nil, nil
 	}
 
-	return &scopes[0], nil
+	return scope, nil
 }
 
 func (m *mongoBackedRoleManager) AddScope(scope gimlet.Scope) error {

--- a/rolemanager/role_manager_test.go
+++ b/rolemanager/role_manager_test.go
@@ -55,6 +55,13 @@ type RoleManagerSuite struct {
 }
 
 func (s *RoleManagerSuite) SetupSuite() {
+	permissions := []string{"edit", "read"}
+	s.NoError(s.m.RegisterPermissions(permissions))
+	s.Error(s.m.RegisterPermissions(permissions))
+}
+
+func (s *RoleManagerSuite) SetupTest() {
+	s.NoError(s.m.Clear())
 	scope1 := gimlet.Scope{
 		ID:          "1",
 		Resources:   []string{"resource1", "resource2"},
@@ -101,18 +108,6 @@ func (s *RoleManagerSuite) SetupSuite() {
 		Type: "foo",
 	}
 	s.NoError(s.m.AddScope(wrongType))
-
-	permissions := []string{"edit", "read"}
-	s.NoError(s.m.RegisterPermissions(permissions))
-	s.Error(s.m.RegisterPermissions(permissions))
-}
-
-func (s *RoleManagerSuite) SetupTest() {
-	roles, err := s.m.GetAllRoles()
-	s.NoError(err)
-	for _, role := range roles {
-		s.NoError(s.m.DeleteRole(role.ID))
-	}
 }
 
 func (s *RoleManagerSuite) TestGetAndUpdate() {
@@ -372,27 +367,54 @@ func (s *RoleManagerSuite) TestFindRoleWithPermissions() {
 	s.NoError(s.m.UpdateRole(r3))
 
 	// test that we can find the role with the correct criteria
-	r, err := s.m.FindRoleWithPermissions([]string{"resource1", "resource2"}, gimlet.Permissions{"read": 20, "edit": 20})
+	r, err := s.m.FindRoleWithPermissions("project", []string{"resource1", "resource2"}, gimlet.Permissions{"read": 20, "edit": 20})
 	s.NoError(err)
-	s.Equal(r.ID, "r1")
+	s.Equal("r1", r.ID)
 	// make sure that order does not matter
-	r, err = s.m.FindRoleWithPermissions([]string{"resource2", "resource1"}, gimlet.Permissions{"edit": 20, "read": 20})
+	r, err = s.m.FindRoleWithPermissions("project", []string{"resource2", "resource1"}, gimlet.Permissions{"edit": 20, "read": 20})
 	s.NoError(err)
-	s.Equal(r.ID, "r1")
+	s.Equal("r1", r.ID)
+	// making such a role should not return anything
+	r, err = MakeRoleWithPermissions(s.m, "project", []string{"resource2", "resource1"}, gimlet.Permissions{"edit": 20, "read": 20})
+	s.NoError(err)
+	s.Equal("r1", r.ID)
+	allRoles, err := s.m.GetAllRoles()
+	s.NoError(err)
+	s.Len(allRoles, 3)
 	// non-matching permissions should find nothing
-	r, err = s.m.FindRoleWithPermissions([]string{"resource2", "resource1"}, gimlet.Permissions{"edit": 10, "read": 20})
+	r, err = s.m.FindRoleWithPermissions("project", []string{"resource2", "resource1"}, gimlet.Permissions{"edit": 10, "read": 20})
 	s.NoError(err)
 	s.Nil(r)
+	// making such a role should create a new role with the existing scope
+	r, err = MakeRoleWithPermissions(s.m, "project", []string{"resource2", "resource1"}, gimlet.Permissions{"edit": 10, "read": 20})
+	s.NoError(err)
+	s.Len(r.ID, 24)
+	s.Equal("1", r.Scope)
+	allRoles, err = s.m.GetAllRoles()
+	s.NoError(err)
+	s.Len(allRoles, 4)
 	// wrong resources should find nothing
-	r, err = s.m.FindRoleWithPermissions([]string{"resource2"}, gimlet.Permissions{"edit": 20, "read": 20})
+	r, err = s.m.FindRoleWithPermissions("project", []string{"resource2"}, gimlet.Permissions{"edit": 20, "read": 20})
 	s.NoError(err)
 	s.Nil(r)
-	r, err = s.m.FindRoleWithPermissions([]string{"resource2", "resource3"}, gimlet.Permissions{"edit": 20, "read": 20})
+	r, err = s.m.FindRoleWithPermissions("project", []string{"resource2", "resource3"}, gimlet.Permissions{"edit": 20, "read": 20})
 	s.NoError(err)
 	s.Nil(r)
-	r, err = s.m.FindRoleWithPermissions([]string{"resource2", "resource3"}, gimlet.Permissions{})
+	r, err = s.m.FindRoleWithPermissions("project", []string{"resource2", "resource3"}, gimlet.Permissions{})
 	s.NoError(err)
 	s.Nil(r)
+	// wrong type should find nothing
+	r, err = s.m.FindRoleWithPermissions("distro", []string{"resource1", "resource2"}, gimlet.Permissions{"read": 20, "edit": 20})
+	s.NoError(err)
+	s.Nil(r)
+	// making such a role should create a new role and scope
+	r, err = MakeRoleWithPermissions(s.m, "distro", []string{"resource1", "resource2"}, gimlet.Permissions{"read": 20, "edit": 20})
+	s.NoError(err)
+	s.Len(r.ID, 24)
+	s.Len(r.Scope, 24)
+	allRoles, err = s.m.GetAllRoles()
+	s.NoError(err)
+	s.Len(allRoles, 5)
 }
 
 func (s *RoleManagerSuite) TestHighestPermissionsForRolesAndResourceType() {
@@ -430,4 +452,26 @@ func (s *RoleManagerSuite) TestHighestPermissionsForRolesAndResourceType() {
 	highestPermissions, err := HighestPermissionsForRolesAndResourceType([]string{"r1", "r2", "r3"}, "project", s.m)
 	s.NoError(err)
 	s.Equal(expectedMap, highestPermissions)
+}
+
+func (s *RoleManagerSuite) TestFindScopeForResources() {
+	// normal scenario where scope exists
+	scope, err := s.m.FindScopeForResources("project", "resource1", "resource2")
+	s.NoError(err)
+	s.Equal(scope.ID, "1")
+	// order should not matter
+	scope, err = s.m.FindScopeForResources("project", "resource2", "resource1")
+	s.NoError(err)
+	s.Equal(scope.ID, "1")
+	// not exact match should find nothing
+	scope, err = s.m.FindScopeForResources("project", "resource2", "resource3")
+	s.NoError(err)
+	s.Nil(scope)
+	scope, err = s.m.FindScopeForResources("project", "foo")
+	s.NoError(err)
+	s.Nil(scope)
+	// wrong type
+	scope, err = s.m.FindScopeForResources("distro", "resource1", "resource2")
+	s.NoError(err)
+	s.Nil(scope)
 }


### PR DESCRIPTION
- Assume that scopes always have all their relevant resources listed within them
- Add a method to find a role with given permissions. This isn't used yet, but will be used by MANA to find an existing role that matches what permissions the user requests