### PR TITLE
EVG-7020 add default permissions

### DIFF
--- a/auth_interfaces.go
+++ b/auth_interfaces.go
@@ -3,6 +3,9 @@ package gimlet
 import (
 	"context"
 	"net/http"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 )
 
 // User provides a common way of interacting with users from
@@ -16,7 +19,7 @@ type User interface {
 	Username() string
 	GetAPIKey() string
 	Roles() []string
-	HasPermission(PermissionOpts) (bool, error)
+	HasPermission(PermissionOpts) bool
 }
 
 // PermissionOpts is the required data to be provided when asking if a user has permission for a resource
@@ -120,4 +123,22 @@ type RoleManager interface {
 
 	// Clear deletes all roles and scopes. This should only be used in tests
 	Clear() error
+}
+
+func HasPermission(rm RoleManager, opts PermissionOpts, roles []Role) bool {
+	roles, err := rm.FilterForResource(roles, opts.Resource, opts.ResourceType)
+	if err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "error filtering for resource",
+		}))
+		return false
+	}
+
+	for _, role := range roles {
+		level, hasPermission := role.Permissions[opts.Permission]
+		if hasPermission && level >= opts.RequiredLevel {
+			return true
+		}
+	}
+	return false
 }

--- a/auth_mock_test.go
+++ b/auth_mock_test.go
@@ -32,15 +32,13 @@ type MockUser struct {
 	RoleNames    []string
 }
 
-func (u *MockUser) DisplayName() string { return u.Name }
-func (u *MockUser) Email() string       { return u.EmailAddress }
-func (u *MockUser) Username() string    { return u.ID }
-func (u *MockUser) IsNil() bool         { return u.ReportNil }
-func (u *MockUser) GetAPIKey() string   { return u.APIKey }
-func (u *MockUser) Roles() []string     { return u.RoleNames }
-func (u *MockUser) HasPermission(PermissionOpts) (bool, error) {
-	return true, nil
-}
+func (u *MockUser) DisplayName() string               { return u.Name }
+func (u *MockUser) Email() string                     { return u.EmailAddress }
+func (u *MockUser) Username() string                  { return u.ID }
+func (u *MockUser) IsNil() bool                       { return u.ReportNil }
+func (u *MockUser) GetAPIKey() string                 { return u.APIKey }
+func (u *MockUser) Roles() []string                   { return u.RoleNames }
+func (u *MockUser) HasPermission(PermissionOpts) bool { return true }
 
 type MockAuthenticator struct {
 	ResourceUserMapping     map[string]string

--- a/auth_user_basic.go
+++ b/auth_user_basic.go
@@ -1,5 +1,10 @@
 package gimlet
 
+import (
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+)
+
 // NewBasicUser constructs a simple user. The underlying type has
 // serialization tags.
 func NewBasicUser(id, name, email, password, key string, roles []string, invalid bool, rm RoleManager) User {
@@ -39,23 +44,15 @@ func (u *basicUser) Roles() []string {
 	copy(out, u.AccessRoles)
 	return out
 }
-func (u *basicUser) HasPermission(opts PermissionOpts) (bool, error) {
+func (u *basicUser) HasPermission(opts PermissionOpts) bool {
 	roles, err := u.roleManager.GetRoles(u.Roles())
 	if err != nil {
-		return false, err
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "error getting roles",
+		}))
+		return false
 	}
-	roles, err = u.roleManager.FilterForResource(roles, opts.Resource, opts.ResourceType)
-	if err != nil {
-		return false, err
-	}
-
-	for _, role := range roles {
-		level, hasPermission := role.Permissions[opts.Permission]
-		if hasPermission && level >= opts.RequiredLevel {
-			return true, nil
-		}
-	}
-	return false, nil
+	return HasPermission(u.roleManager, opts, roles)
 }
 
 // userHasRole determines if the user has the defined role.

--- a/ldap/ldap_test.go
+++ b/ldap/ldap_test.go
@@ -175,14 +175,12 @@ func (m *mockConn) SearchWithPaging(searchRequest *ldap.SearchRequest, pagingSiz
 
 type mockUser struct{ name string }
 
-func (u *mockUser) DisplayName() string { return "" }
-func (u *mockUser) Email() string       { return "" }
-func (u *mockUser) Username() string    { return u.name }
-func (u *mockUser) GetAPIKey() string   { return "" }
-func (u *mockUser) Roles() []string     { return []string{} }
-func (u *mockUser) HasPermission(gimlet.PermissionOpts) (bool, error) {
-	return true, nil
-}
+func (u *mockUser) DisplayName() string                      { return "" }
+func (u *mockUser) Email() string                            { return "" }
+func (u *mockUser) Username() string                         { return u.name }
+func (u *mockUser) GetAPIKey() string                        { return "" }
+func (u *mockUser) Roles() []string                          { return []string{} }
+func (u *mockUser) HasPermission(gimlet.PermissionOpts) bool { return true }
 
 // TODO
 var mockPutUser gimlet.User

--- a/middleware_auth.go
+++ b/middleware_auth.go
@@ -251,6 +251,7 @@ type RequiresPermissionMiddlewareOpts struct {
 	ResourceType   string
 	RequiredLevel  int
 	ResourceLevels []string
+	DefaultRoles   []Role
 	ResourceFunc   FindResourceFunc
 }
 
@@ -265,24 +266,6 @@ func RequiresPermission(opts RequiresPermissionMiddlewareOpts) Middleware {
 
 func (rp *requiresPermissionHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	ctx := r.Context()
-
-	user := GetUser(ctx)
-	if user == nil {
-		http.Error(rw, "no user found", http.StatusUnauthorized)
-		return
-	}
-
-	authenticator := GetAuthenticator(ctx)
-	if authenticator == nil {
-		http.Error(rw, "unable to determine an authenticator", http.StatusInternalServerError)
-		return
-	}
-
-	if !authenticator.CheckAuthenticated(user) {
-		http.Error(rw, "not authenticated", http.StatusUnauthorized)
-		return
-	}
-
 	vars := GetVars(r)
 	var resource string
 	var status int
@@ -302,24 +285,40 @@ func (rp *requiresPermissionHandler) ServeHTTP(rw http.ResponseWriter, r *http.R
 		}
 	}
 
-	if resource != "" {
-		opts := PermissionOpts{
-			Resource:      resource,
-			ResourceType:  rp.opts.ResourceType,
-			Permission:    rp.opts.PermissionKey,
-			RequiredLevel: rp.opts.RequiredLevel,
-		}
-		hasPermission, err := user.HasPermission(opts)
-		grip.Error(message.WrapError(err, message.Fields{
-			"message":    "error checking permissions",
-			"user":       user.Username(),
-			"permission": rp.opts.PermissionKey,
-		}))
+	opts := PermissionOpts{
+		Resource:      resource,
+		ResourceType:  rp.opts.ResourceType,
+		Permission:    rp.opts.PermissionKey,
+		RequiredLevel: rp.opts.RequiredLevel,
+	}
 
-		if !hasPermission {
-			http.Error(rw, "not authorized for this action", http.StatusUnauthorized)
-			return
+	user := GetUser(ctx)
+	if user == nil {
+		if rp.opts.DefaultRoles != nil {
+			if !HasPermission(rp.opts.RM, opts, rp.opts.DefaultRoles) {
+				http.Error(rw, "not authorized for this action", http.StatusUnauthorized)
+				return
+			}
+			next(rw, r)
 		}
+		http.Error(rw, "no user found", http.StatusUnauthorized)
+		return
+	}
+
+	authenticator := GetAuthenticator(ctx)
+	if authenticator == nil {
+		http.Error(rw, "unable to determine an authenticator", http.StatusInternalServerError)
+		return
+	}
+
+	if !authenticator.CheckAuthenticated(user) {
+		http.Error(rw, "not authenticated", http.StatusUnauthorized)
+		return
+	}
+
+	if !user.HasPermission(opts) {
+		http.Error(rw, "not authorized for this action", http.StatusUnauthorized)
+		return
 	}
 
 	next(rw, r)

--- a/rolemanager/role_manager_test.go
+++ b/rolemanager/role_manager_test.go
@@ -286,12 +286,12 @@ func (s *RoleManagerSuite) TestRequiresPermissionMiddleware() {
 	s.Equal(http.StatusUnauthorized, rw.Code)
 	s.Equal(1, counter)
 
-	// no resource found = allowed
+	// no resource found = not allowed
 	rw = httptest.NewRecorder()
 	req = mux.SetURLVars(req, map[string]string{})
 	authHandler.ServeHTTP(rw, req, checkPermission)
-	s.Equal(http.StatusOK, rw.Code)
-	s.Equal(2, counter)
+	s.Equal(http.StatusUnauthorized, rw.Code)
+	s.Equal(1, counter)
 }
 
 func (s *RoleManagerSuite) TestHighestPermissionsForRoles() {


### PR DESCRIPTION
- Add the concept of default roles, which are given to users that are not logged in. This should allow us to remove the RequiresProjectViewPermission middleware in evergreen
- Simplify the signature of user.HasPermission so that it only returns a bool