### PR TITLE
MAKE-1093: refactor user cache and add access/refresh tokens

### DIFF
--- a/auth_basic_test.go
+++ b/auth_basic_test.go
@@ -26,7 +26,7 @@ func TestSimpleAuthenticator(t *testing.T) {
 	assert.Len(auth.(*simpleAuthenticator).users, 0)
 
 	// constructor avoids nils
-	usr := NewBasicUser("id", "name", "email", "pass", "key", []string{}, false, nil)
+	usr := NewBasicUser("id", "name", "email", "pass", "key", "", "", []string{}, false, nil)
 	auth = NewSimpleAuthenticator([]User{usr}, nil)
 	assert.NotNil(auth)
 	assert.NotNil(auth.(*simpleAuthenticator).groups)
@@ -38,11 +38,11 @@ func TestSimpleAuthenticator(t *testing.T) {
 	assert.True(auth.CheckAuthenticated(usr))
 
 	// a second user shouldn't validate
-	usr2 := NewBasicUser("id2", "name", "email", "pass", "key", []string{}, false, nil)
+	usr2 := NewBasicUser("id2", "name", "email", "pass", "key", "", "", []string{}, false, nil)
 	assert.False(auth.CheckAuthenticated(usr2))
 
-	usr3 := NewBasicUser("id3", "name", "email", "pass", "key", []string{"admin"}, false, nil)
-	usr3broken := NewBasicUser("id3", "name", "email", "pass", "yek", []string{"admin"}, false, nil)
+	usr3 := NewBasicUser("id3", "name", "email", "pass", "key", "", "", []string{"admin"}, false, nil)
+	usr3broken := NewBasicUser("id3", "name", "email", "pass", "yek", "", "", []string{"admin"}, false, nil)
 	auth = NewSimpleAuthenticator([]User{usr3}, map[string][]string{
 		"none":  []string{"_"},
 		"admin": []string{"id3"}})
@@ -78,7 +78,7 @@ func TestBasicAuthenticator(t *testing.T) {
 	// usernames
 	assert.False(auth.CheckAuthenticated(nil))
 	assert.False(auth.CheckAuthenticated(&basicUser{}))
-	usr := NewBasicUser("id", "name", "email", "pass", "key", []string{}, false, nil)
+	usr := NewBasicUser("id", "name", "email", "pass", "key", "", "", []string{}, false, nil)
 	assert.True(auth.CheckAuthenticated(usr))
 
 	auth = NewBasicAuthenticator(map[string][]string{"one": []string{"id"}}, nil)

--- a/auth_interfaces.go
+++ b/auth_interfaces.go
@@ -17,6 +17,11 @@ type User interface {
 	GetAPIKey() string
 	Roles() []string
 	HasPermission(PermissionOpts) (bool, error)
+
+	// These only apply to systems that require token-based authorization
+	// (e.g. Okta).
+	GetAccessToken() string
+	GetRefreshToken() string
 }
 
 // PermissionOpts is the required data to be provided when asking if a user has permission for a resource

--- a/auth_mock_test.go
+++ b/auth_mock_test.go
@@ -29,15 +29,19 @@ type MockUser struct {
 	EmailAddress string
 	ReportNil    bool
 	APIKey       string
+	AccessToken  string
+	RefreshToken string
 	RoleNames    []string
 }
 
-func (u *MockUser) DisplayName() string { return u.Name }
-func (u *MockUser) Email() string       { return u.EmailAddress }
-func (u *MockUser) Username() string    { return u.ID }
-func (u *MockUser) IsNil() bool         { return u.ReportNil }
-func (u *MockUser) GetAPIKey() string   { return u.APIKey }
-func (u *MockUser) Roles() []string     { return u.RoleNames }
+func (u *MockUser) DisplayName() string     { return u.Name }
+func (u *MockUser) Email() string           { return u.EmailAddress }
+func (u *MockUser) Username() string        { return u.ID }
+func (u *MockUser) IsNil() bool             { return u.ReportNil }
+func (u *MockUser) GetAPIKey() string       { return u.APIKey }
+func (u *MockUser) GetAccessToken() string  { return u.AccessToken }
+func (u *MockUser) GetRefreshToken() string { return u.RefreshToken }
+func (u *MockUser) Roles() []string         { return u.RoleNames }
 func (u *MockUser) HasPermission(PermissionOpts) (bool, error) {
 	return true, nil
 }

--- a/auth_user_basic.go
+++ b/auth_user_basic.go
@@ -2,13 +2,15 @@ package gimlet
 
 // NewBasicUser constructs a simple user. The underlying type has
 // serialization tags.
-func NewBasicUser(id, name, email, password, key string, roles []string, invalid bool, rm RoleManager) User {
+func NewBasicUser(id, name, email, password, key string, accessToken, refreshToken string, roles []string, invalid bool, rm RoleManager) User {
 	return &basicUser{
 		ID:           id,
 		Name:         name,
 		EmailAddress: email,
 		Password:     password,
 		Key:          key,
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
 		AccessRoles:  roles,
 		Invalid:      invalid,
 		roleManager:  rm,
@@ -25,15 +27,19 @@ type basicUser struct {
 	EmailAddress string   `bson:"email" json:"email" yaml:"email"`
 	Password     string   `bson:"password" json:"password" yaml:"password"`
 	Key          string   `bson:"key" json:"key" yaml:"key"`
+	AccessToken  string   `bson:"access_token,omitempty" json:"access_token,omitempty" yaml:"access_token,omitempty"`
+	RefreshToken string   `bson:"refresh_token,omitempty" json:"refresh_token,omitempty" yaml:"refresh_token,omitempty"`
 	AccessRoles  []string `bson:"roles" json:"roles" yaml:"roles"`
 	Invalid      bool     `bson:"invalid" json:"invalid" yaml:"invalid"`
 	roleManager  RoleManager
 }
 
-func (u *basicUser) Username() string    { return u.ID }
-func (u *basicUser) Email() string       { return u.EmailAddress }
-func (u *basicUser) DisplayName() string { return u.Name }
-func (u *basicUser) GetAPIKey() string   { return u.Key }
+func (u *basicUser) Username() string        { return u.ID }
+func (u *basicUser) Email() string           { return u.EmailAddress }
+func (u *basicUser) DisplayName() string     { return u.Name }
+func (u *basicUser) GetAPIKey() string       { return u.Key }
+func (u *basicUser) GetAccessToken() string  { return u.AccessToken }
+func (u *basicUser) GetRefreshToken() string { return u.RefreshToken }
 func (u *basicUser) Roles() []string {
 	out := make([]string, len(u.AccessRoles))
 	copy(out, u.AccessRoles)

--- a/auth_user_basic_test.go
+++ b/auth_user_basic_test.go
@@ -12,8 +12,8 @@ func TestBasicUserImplementation(t *testing.T) {
 	// constructors
 	assert.Implements((*User)(nil), &basicUser{})
 	assert.Implements((*User)(nil), MakeBasicUser())
-	assert.Implements((*User)(nil), NewBasicUser("", "", "", "", "", []string{}, false, nil))
-	assert.Equal(MakeBasicUser(), NewBasicUser("", "", "", "", "", nil, false, nil))
+	assert.Implements((*User)(nil), NewBasicUser("", "", "", "", "", "", "", []string{}, false, nil))
+	assert.Equal(MakeBasicUser(), NewBasicUser("", "", "", "", "", "", "", nil, false, nil))
 
 	var usr *basicUser
 
@@ -22,6 +22,8 @@ func TestBasicUserImplementation(t *testing.T) {
 		ID:           "usrid",
 		EmailAddress: "usr@example.net",
 		Key:          "sekret",
+		AccessToken:  "access",
+		RefreshToken: "refresh",
 		AccessRoles:  []string{"admin"},
 		Name:         "name",
 	}
@@ -29,6 +31,8 @@ func TestBasicUserImplementation(t *testing.T) {
 	assert.Equal(usr.Username(), "usrid")
 	assert.Equal(usr.Email(), "usr@example.net")
 	assert.Equal(usr.GetAPIKey(), "sekret")
+	assert.Equal(usr.GetAccessToken(), "access")
+	assert.Equal(usr.GetRefreshToken(), "refresh")
 	assert.Equal(usr.Roles()[0], "admin")
 	assert.Equal(usr.DisplayName(), "name")
 

--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -491,5 +491,5 @@ func makeUser(result *ldap.SearchResult) gimlet.User {
 			groups = append(groups, entry.Values...)
 		}
 	}
-	return gimlet.NewBasicUser(id, name, email, "", "", groups, false, nil)
+	return gimlet.NewBasicUser(id, name, email, "", "", "", "", groups, false, nil)
 }

--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/gimlet/usercache"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -25,7 +26,7 @@ type userService struct {
 	userGroup    string
 	serviceGroup string
 	groupOuName  string
-	cache        UserCache
+	cache        usercache.Cache
 	connect      connectFunc
 	conn         ldap.Client
 }
@@ -40,13 +41,9 @@ type CreationOpts struct {
 	ServiceGroup string // LDAP serviceGroup to authorize services
 	GroupOuName  string // name of the OU that lists a user's groups
 
-	UserCache UserCache
+	UserCache usercache.Cache
 	// Functions to produce a UserCache
-	PutCache      PutUserGetToken // Put user to cache
-	GetCache      GetUserByToken  // Get user from cache
-	ClearCache    ClearUserToken  // Remove user(s) from cache
-	GetUser       GetUserByID     // Get user from storage
-	GetCreateUser GetOrCreateUser // Get or create user from storage
+	ExternalCache *usercache.ExternalOptions
 
 	connect connectFunc // connect changes connection behavior for testing
 }
@@ -81,8 +78,18 @@ func NewUserService(opts CreationOpts) (gimlet.UserManager, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err
 	}
+	var cache usercache.Cache
+	if opts.UserCache != nil {
+		cache = opts.UserCache
+	} else {
+		var err error
+		cache, err = usercache.NewExternal(*opts.ExternalCache)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not create user cache")
+		}
+	}
 	u := &userService{
-		cache:        opts.MakeUserCache(),
+		cache:        cache,
 		connect:      connect,
 		url:          opts.URL,
 		port:         opts.Port,
@@ -105,21 +112,16 @@ func (opts CreationOpts) validate() error {
 	catcher := grip.NewBasicCatcher()
 
 	if opts.URL == "" || opts.Port == "" || opts.UserPath == "" || opts.ServicePath == "" {
-		catcher.Add(errors.Errorf("URL ('%s'), Port ('%s'), UserPath ('%s') and ServicePath ('%s') must be provided",
-			opts.URL, opts.Port, opts.UserPath, opts.ServicePath))
+		catcher.Errorf("URL ('%s'), Port ('%s'), UserPath ('%s') and ServicePath ('%s') must be provided",
+			opts.URL, opts.Port, opts.UserPath, opts.ServicePath)
 	}
 
 	if opts.UserGroup == "" {
-		catcher.Add(errors.New("LDAP user group cannot be empty"))
+		catcher.New("LDAP user group cannot be empty")
 	}
 
-	if opts.UserCache == nil {
-		if opts.PutCache == nil || opts.GetCache == nil || opts.ClearCache == nil {
-			catcher.Add(errors.New("PutCache, GetCache, and ClearCache must not be nil"))
-		}
-		if opts.GetUser == nil || opts.GetCreateUser == nil {
-			catcher.Add(errors.New("GetUserByID and GetOrCreateUser must not be nil"))
-		}
+	if opts.UserCache == nil && opts.ExternalCache == nil {
+		catcher.New("must specify user cache")
 	}
 
 	return catcher.Resolve()

--- a/ldap/ldap_test.go
+++ b/ldap/ldap_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/gimlet/usercache"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
 	ldap "gopkg.in/ldap.v2"
@@ -28,69 +29,77 @@ func (s *LDAPSuite) SetupTest() {
 	var err error
 	mockPutUser = nil
 	s.um, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "cn=10gen,ou=groups,dc=mongodb,dc=com",
-		GroupOuName:   "groups",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		connect:       mockConnect,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "cn=10gen,ou=groups,dc=mongodb,dc=com",
+		GroupOuName: "groups",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
+		connect: mockConnect,
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(s.um)
 
 	s.serviceGroupUm, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "badgroup",
-		ServiceGroup:  "cn=10gen,ou=groups,dc=mongodb,dc=com",
-		GroupOuName:   "groups",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		connect:       mockConnect,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:          "url",
+		Port:         "port",
+		UserPath:     "path",
+		ServicePath:  "bots",
+		UserGroup:    "badgroup",
+		ServiceGroup: "cn=10gen,ou=groups,dc=mongodb,dc=com",
+		GroupOuName:  "groups",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
+		connect: mockConnect,
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(s.um)
 
 	s.badGroupUm, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "badgroup",
-		GroupOuName:   "groups",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		connect:       mockConnectErr,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "badgroup",
+		GroupOuName: "groups",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
+		connect: mockConnectErr,
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(s.badGroupUm)
 
 	s.realConnUm, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "badgroup",
-		GroupOuName:   "groups",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "badgroup",
+		GroupOuName: "groups",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(s.badGroupUm)
@@ -215,7 +224,7 @@ func mockGetMissing(token string) (gimlet.User, bool, error) {
 	return nil, false, nil
 }
 
-func mockClearCache(u gimlet.User, all bool) error {
+func mockClearUserToken(u gimlet.User, all bool) error {
 	return nil
 }
 
@@ -231,151 +240,171 @@ func mockGetOrCreateUser(user gimlet.User) (gimlet.User, error) {
 
 func (s *LDAPSuite) TestLDAPConstructorRequiresNonEmptyArgs() {
 	l, err := NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "group",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "group",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.NoError(err)
 	s.NotNil(l)
 
 	l, err = NewUserService(CreationOpts{
-		URL:           "",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "group",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "group",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.Error(err)
 	s.Nil(l)
 
 	l, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "group",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "group",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.Error(err)
 	s.Nil(l)
 
 	l, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "",
-		ServicePath:   "bots",
-		UserGroup:     "group",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "",
+		ServicePath: "bots",
+		UserGroup:   "group",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.Error(err)
 	s.Nil(l)
 
 	l, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.Error(err)
 	s.Nil(l)
 
 	l, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "group",
-		PutCache:      nil,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "group",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: nil,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.Error(err)
 	s.Nil(l)
 
 	l, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "group",
-		PutCache:      mockPutSuccess,
-		GetCache:      nil,
-		ClearCache:    mockClearCache,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "group",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  nil,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.Error(err)
 	s.Nil(l)
 
 	l, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "group",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    nil,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "group",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  nil,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.Error(err)
 	s.Nil(l)
 
 	l, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "group",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		GetUser:       nil,
-		GetCreateUser: mockGetOrCreateUser,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "group",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     nil,
+			GetOrCreateUser: mockGetOrCreateUser,
+		},
 	})
 	s.Error(err)
 	s.Nil(l)
 
 	l, err = NewUserService(CreationOpts{
-		URL:           "url",
-		Port:          "port",
-		UserPath:      "path",
-		ServicePath:   "bots",
-		UserGroup:     "group",
-		PutCache:      mockPutSuccess,
-		GetCache:      mockGetValid,
-		ClearCache:    mockClearCache,
-		GetUser:       mockGetUserByID,
-		GetCreateUser: nil,
+		URL:         "url",
+		Port:        "port",
+		UserPath:    "path",
+		ServicePath: "bots",
+		UserGroup:   "group",
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: mockPutSuccess,
+			GetUserByToken:  mockGetValid,
+			ClearUserToken:  mockClearUserToken,
+			GetUserByID:     mockGetUserByID,
+			GetOrCreateUser: nil,
+		},
 	})
 	s.Error(err)
 	s.Nil(l)
@@ -384,33 +413,33 @@ func (s *LDAPSuite) TestLDAPConstructorRequiresNonEmptyArgs() {
 func (s *LDAPSuite) TestGetUserByToken() {
 	ctx := context.Background()
 
-	impl, ok := s.um.(*userService).cache.(*externalUserCache)
+	impl, ok := s.um.(*userService).cache.(*usercache.ExternalCache)
 	s.True(ok)
-	impl.get = mockGetErr
+	impl.Opts.GetUserByToken = mockGetErr
 	u, err := s.um.GetUserByToken(ctx, "foo")
 	s.Error(err)
 	s.Nil(u)
 
-	impl.get = mockGetValid
+	impl.Opts.GetUserByToken = mockGetValid
 	u, err = s.um.GetUserByToken(ctx, "foo")
 	s.NoError(err)
 	s.Equal("foo", u.Username())
 
-	impl.get = mockGetExpired
+	impl.Opts.GetUserByToken = mockGetExpired
 	u, err = s.um.GetUserByToken(ctx, "foo")
 	s.NoError(err)
 	s.Equal("foo", u.Username())
 
-	serviceGroupImpl, ok := s.serviceGroupUm.(*userService).cache.(*externalUserCache)
+	serviceGroupImpl, ok := s.serviceGroupUm.(*userService).cache.(*usercache.ExternalCache)
 	s.True(ok)
-	serviceGroupImpl.get = mockGetExpired
+	serviceGroupImpl.Opts.GetUserByToken = mockGetExpired
 	u, err = s.badGroupUm.GetUserByToken(ctx, "foo")
 	s.NoError(err)
 	s.Equal("foo", u.Username())
 
-	badGroupImpl, ok := s.badGroupUm.(*userService).cache.(*externalUserCache)
+	badGroupImpl, ok := s.badGroupUm.(*userService).cache.(*usercache.ExternalCache)
 	s.True(ok)
-	badGroupImpl.get = mockGetExpired
+	badGroupImpl.Opts.GetUserByToken = mockGetExpired
 	u, err = s.badGroupUm.GetUserByToken(ctx, "foo")
 	s.Error(err)
 	s.Nil(u)
@@ -419,14 +448,14 @@ func (s *LDAPSuite) TestGetUserByToken() {
 	s.Error(err)
 	s.Nil(u)
 
-	impl.get = mockGetMissing
+	impl.Opts.GetUserByToken = mockGetMissing
 	u, err = s.um.GetUserByToken(ctx, "foo")
 	s.Error(err)
 	s.Nil(u)
 
-	realConnImpl, ok := s.realConnUm.(*userService).cache.(*externalUserCache)
+	realConnImpl, ok := s.realConnUm.(*userService).cache.(*usercache.ExternalCache)
 	s.True(ok)
-	realConnImpl.get = mockGetExpired
+	realConnImpl.Opts.GetUserByToken = mockGetExpired
 	u, err = s.realConnUm.GetUserByToken(ctx, "foo")
 	s.Error(err)
 	s.Nil(u)
@@ -450,9 +479,9 @@ func (s *LDAPSuite) TestCreateUserToken() {
 	s.Error(err)
 	s.Empty(token)
 
-	impl, ok := s.um.(*userService).cache.(*externalUserCache)
+	impl, ok := s.um.(*userService).cache.(*usercache.ExternalCache)
 	s.True(ok)
-	impl.put = mockPutErr
+	impl.Opts.PutUserGetToken = mockPutErr
 	token, err = s.um.CreateUserToken("foo", "hunter2")
 	s.Error(err)
 	s.Empty(token)
@@ -479,33 +508,33 @@ func (s *LDAPSuite) TestIsRedirect() {
 }
 
 func (s *LDAPSuite) TestGetUser() {
-	impl, ok := s.um.(*userService).cache.(*externalUserCache)
+	impl, ok := s.um.(*userService).cache.(*usercache.ExternalCache)
 	s.True(ok)
-	impl.find = mockGetErr
+	impl.Opts.GetUserByID = mockGetErr
 	u, err := s.um.GetUserByID("foo")
 	s.Error(err)
 	s.Nil(u)
 
-	impl.find = mockGetValid
+	impl.Opts.GetUserByID = mockGetValid
 	u, err = s.um.GetUserByID("foo")
 	s.NoError(err)
 	s.Equal("foo", u.Username())
 
-	impl.find = mockGetExpired
+	impl.Opts.GetUserByID = mockGetExpired
 	u, err = s.um.GetUserByID("foo")
 	s.NoError(err)
 	s.Equal("foo", u.Username())
 
-	serviceGroupImpl, ok := s.serviceGroupUm.(*userService).cache.(*externalUserCache)
+	serviceGroupImpl, ok := s.serviceGroupUm.(*userService).cache.(*usercache.ExternalCache)
 	s.True(ok)
-	serviceGroupImpl.find = mockGetExpired
+	serviceGroupImpl.Opts.GetUserByID = mockGetExpired
 	u, err = s.badGroupUm.GetUserByID("foo")
 	s.NoError(err)
 	s.Equal("foo", u.Username())
 
-	badGroupImpl, ok := s.badGroupUm.(*userService).cache.(*externalUserCache)
+	badGroupImpl, ok := s.badGroupUm.(*userService).cache.(*usercache.ExternalCache)
 	s.True(ok)
-	badGroupImpl.find = mockGetExpired
+	badGroupImpl.Opts.GetUserByID = mockGetExpired
 	u, err = s.badGroupUm.GetUserByID("foo")
 	s.Error(err)
 	s.Nil(u)
@@ -514,14 +543,14 @@ func (s *LDAPSuite) TestGetUser() {
 	s.Error(err)
 	s.Nil(u)
 
-	impl.find = mockGetMissing
+	impl.Opts.GetUserByID = mockGetMissing
 	u, err = s.um.GetUserByID("foo")
 	s.Error(err)
 	s.Nil(u)
 
-	realConnImpl, ok := s.realConnUm.(*userService).cache.(*externalUserCache)
+	realConnImpl, ok := s.realConnUm.(*userService).cache.(*usercache.ExternalCache)
 	s.True(ok)
-	realConnImpl.find = mockGetExpired
+	realConnImpl.Opts.GetUserByID = mockGetExpired
 	u, err = s.realConnUm.GetUserByID("foo")
 	s.Error(err)
 	s.Nil(u)
@@ -543,7 +572,7 @@ func (s *LDAPSuite) TestLoginUsesBothPaths() {
 	s.NoError(userManager.login("foo", "hunter3"))
 }
 
-func (s *LDAPSuite) TestClearCache() {
+func (s *LDAPSuite) TestClearUserToken() {
 	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil)
 	user, err := s.um.GetOrCreateUser(basicUser)
 	s.Require().NoError(err)

--- a/ldap/ldap_test.go
+++ b/ldap/ldap_test.go
@@ -184,11 +184,13 @@ func (m *mockConn) SearchWithPaging(searchRequest *ldap.SearchRequest, pagingSiz
 
 type mockUser struct{ name string }
 
-func (u *mockUser) DisplayName() string { return "" }
-func (u *mockUser) Email() string       { return "" }
-func (u *mockUser) Username() string    { return u.name }
-func (u *mockUser) GetAPIKey() string   { return "" }
-func (u *mockUser) Roles() []string     { return []string{} }
+func (u *mockUser) DisplayName() string     { return "" }
+func (u *mockUser) Email() string           { return "" }
+func (u *mockUser) Username() string        { return u.name }
+func (u *mockUser) GetAPIKey() string       { return "" }
+func (u *mockUser) GetAccessToken() string  { return "" }
+func (u *mockUser) GetRefreshToken() string { return "" }
+func (u *mockUser) Roles() []string         { return []string{} }
 func (u *mockUser) HasPermission(gimlet.PermissionOpts) (bool, error) {
 	return true, nil
 }
@@ -229,12 +231,12 @@ func mockClearUserToken(u gimlet.User, all bool) error {
 }
 
 func mockGetUserByID(id string) (gimlet.User, bool, error) {
-	u := gimlet.NewBasicUser(id, "", "", "", "", []string{}, false, nil)
+	u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, false, nil)
 	return u, true, nil
 }
 
 func mockGetOrCreateUser(user gimlet.User) (gimlet.User, error) {
-	u := gimlet.NewBasicUser(user.Username(), user.DisplayName(), user.Email(), "", user.GetAPIKey(), []string{}, false, nil)
+	u := gimlet.NewBasicUser(user.Username(), user.DisplayName(), user.Email(), "", user.GetAPIKey(), "", "", []string{}, false, nil)
 	return u, nil
 }
 
@@ -557,7 +559,7 @@ func (s *LDAPSuite) TestGetUser() {
 }
 
 func (s *LDAPSuite) TestGetOrCreateUser() {
-	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil)
+	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil)
 	user, err := s.um.GetOrCreateUser(basicUser)
 	s.NoError(err)
 	s.Equal("foo", user.Username())
@@ -573,7 +575,7 @@ func (s *LDAPSuite) TestLoginUsesBothPaths() {
 }
 
 func (s *LDAPSuite) TestClearUserToken() {
-	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil)
+	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil)
 	user, err := s.um.GetOrCreateUser(basicUser)
 	s.Require().NoError(err)
 

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/gimlet/util"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	verifier "github.com/okta/okta-jwt-verifier-golang"
@@ -90,7 +91,7 @@ const (
 func (m *userManager) GetLoginHandler(callbackURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// TODO (kim): persist nonce and state.
-		nonce, err := randomString()
+		nonce, err := util.RandomString()
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not get login handler",
@@ -98,7 +99,7 @@ func (m *userManager) GetLoginHandler(callbackURL string) http.HandlerFunc {
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(errors.Wrap(err, "could not get login handler")))
 			return
 		}
-		state, err := randomString()
+		state, err := util.RandomString()
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "could not get login handler",

--- a/rolemanager/role_manager_test.go
+++ b/rolemanager/role_manager_test.go
@@ -247,7 +247,7 @@ func (s *RoleManagerSuite) TestRequiresPermissionMiddleware() {
 		permissionMiddleware.ServeHTTP(rw, r, counterFunc)
 	}
 	authenticator := gimlet.NewBasicAuthenticator(nil, nil)
-	user := gimlet.NewBasicUser("user", "name", "email", "password", "key", nil, false, s.m)
+	user := gimlet.NewBasicUser("user", "name", "email", "password", "key", "", "", nil, false, s.m)
 	um, err := gimlet.NewBasicUserManager([]gimlet.User{user}, s.m)
 	s.NoError(err)
 	authHandler := gimlet.NewAuthenticationHandler(authenticator, um)
@@ -269,7 +269,7 @@ func (s *RoleManagerSuite) TestRequiresPermissionMiddleware() {
 	s.Equal(0, counter)
 
 	// give user the right permissions
-	user = gimlet.NewBasicUser("user", "name", "email", "password", "key", []string{role1.ID}, false, s.m)
+	user = gimlet.NewBasicUser("user", "name", "email", "password", "key", "", "", []string{role1.ID}, false, s.m)
 	_, err = um.GetOrCreateUser(user)
 	s.NoError(err)
 	ctx = gimlet.AttachUser(req.Context(), user)

--- a/usercache/cache_test.go
+++ b/usercache/cache_test.go
@@ -37,7 +37,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
 							created: time.Now().Add(-time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
@@ -50,7 +50,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
 							created: time.Now().Add(-time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
@@ -63,7 +63,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
 							created: time.Now().Add(time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
@@ -77,7 +77,7 @@ func TestCache(t *testing.T) {
 						c := cache.(*userCache)
 						c.userToToken["foo"] = "0"
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
 							created: time.Now().Add(time.Hour),
 						}
 						_, _, err := cache.Find("foo")
@@ -89,7 +89,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
 							created: time.Now().Add(-time.Hour),
 						}
 						u, exists, err := cache.Get("foo")
@@ -173,7 +173,7 @@ func TestCache(t *testing.T) {
 				cache, err := impl.factory()
 				require.NoError(t, err)
 				const id = "username"
-				u := gimlet.NewBasicUser(id, "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, false, nil)
 				assert.NoError(t, cache.Add(u))
 				cu, _, err := cache.Find(id)
 				assert.NoError(t, err)
@@ -183,7 +183,7 @@ func TestCache(t *testing.T) {
 				cache, err := impl.factory()
 				require.NoError(t, err)
 				const id = "username"
-				u := gimlet.NewBasicUser(id, "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, false, nil)
 				token, err := cache.Put(u)
 				assert.NoError(t, err)
 				assert.NotZero(t, token)
@@ -214,7 +214,7 @@ func TestCache(t *testing.T) {
 				_, _, err = cache.Find("usr")
 				assert.Error(t, err)
 
-				u := gimlet.NewBasicUser("usr", "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, false, nil)
 
 				cu, err := cache.GetOrCreate(u)
 				require.NoError(t, err)
@@ -229,7 +229,7 @@ func TestCache(t *testing.T) {
 				_, _, err = cache.Find("usr")
 				assert.Error(t, err)
 
-				u := gimlet.NewBasicUser("usr", "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, false, nil)
 
 				_, err = cache.Put(u)
 				require.NoError(t, err)
@@ -241,7 +241,7 @@ func TestCache(t *testing.T) {
 			t.Run("ClearUser", func(t *testing.T) {
 				cache, err := impl.factory()
 				require.NoError(t, err)
-				u := gimlet.NewBasicUser("usr", "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, false, nil)
 				u, err = cache.GetOrCreate(u)
 				require.NoError(t, err)
 				require.NotNil(t, u)

--- a/usercache/cache_test.go
+++ b/usercache/cache_test.go
@@ -1,4 +1,4 @@
-package ldap
+package usercache
 
 import (
 	"context"
@@ -6,38 +6,39 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/gimlet/util"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestUserCache(t *testing.T) {
+func TestCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	type implCases struct {
 		name string
-		test func(*testing.T, UserCache)
+		test func(*testing.T, Cache)
 	}
 
 	for _, impl := range []struct {
 		name    string
-		factory func() UserCache
+		factory func() (Cache, error)
 		cases   []implCases
 	}{
 		{
 			name: "InMemory",
-			factory: func() UserCache {
-				return NewInMemoryUserCache(ctx, time.Millisecond)
+			factory: func() (Cache, error) {
+				return NewInMemory(ctx, time.Millisecond), nil
 			},
 			cases: []implCases{
 				{
 					name: "CleanMethodPrunes",
-					test: func(t *testing.T, cache UserCache) {
+					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user: gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
-							time: time.Now().Add(-time.Hour),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							created: time.Now().Add(-time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
 						c.clean()
@@ -46,11 +47,11 @@ func TestUserCache(t *testing.T) {
 				},
 				{
 					name: "CleanMethodIsRunPeriodically",
-					test: func(t *testing.T, cache UserCache) {
+					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user: gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
-							time: time.Now().Add(-time.Hour),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							created: time.Now().Add(-time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
 						time.Sleep(2 * time.Millisecond)
@@ -59,11 +60,11 @@ func TestUserCache(t *testing.T) {
 				},
 				{
 					name: "CleanLeavesNoTimeout",
-					test: func(t *testing.T, cache UserCache) {
+					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user: gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
-							time: time.Now().Add(time.Hour),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							created: time.Now().Add(time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
 						c.clean()
@@ -72,12 +73,12 @@ func TestUserCache(t *testing.T) {
 				},
 				{
 					name: "FindWithBrokenCache",
-					test: func(t *testing.T, cache UserCache) {
+					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.userToToken["foo"] = "0"
 						c.cache["foo"] = cacheValue{
-							user: gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
-							time: time.Now().Add(time.Hour),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							created: time.Now().Add(time.Hour),
 						}
 						_, _, err := cache.Find("foo")
 						assert.Error(t, err)
@@ -85,11 +86,11 @@ func TestUserCache(t *testing.T) {
 				},
 				{
 					name: "GetRespectsTTL",
-					test: func(t *testing.T, cache UserCache) {
+					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user: gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
-							time: time.Now().Add(-time.Hour),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", []string{}, false, nil),
+							created: time.Now().Add(-time.Hour),
 						}
 						u, exists, err := cache.Get("foo")
 						assert.NoError(t, err)
@@ -101,31 +102,34 @@ func TestUserCache(t *testing.T) {
 		},
 		{
 			name: "ExternalMock",
-			factory: func() UserCache {
+			factory: func() (Cache, error) {
 				users := make(map[string]gimlet.User)
 				cache := make(map[string]gimlet.User)
-				return CreationOpts{
-					PutCache: func(u gimlet.User) (string, error) {
-						token := randStr()
+				return NewExternal(ExternalOptions{
+					PutUserGetToken: func(u gimlet.User) (string, error) {
+						token, err := util.RandomString()
+						if err != nil {
+							return "", errors.WithStack(err)
+						}
 						cache[token] = u
 						return token, nil
 					},
-					GetCache: func(token string) (gimlet.User, bool, error) {
+					GetUserByToken: func(token string) (gimlet.User, bool, error) {
 						u, ok := cache[token]
 						return u, ok, nil
 					},
-					GetUser: func(id string) (gimlet.User, bool, error) {
+					GetUserByID: func(id string) (gimlet.User, bool, error) {
 						u, ok := users[id]
 						if !ok {
 							return nil, false, errors.New("not found")
 						}
 						return u, true, nil
 					},
-					GetCreateUser: func(u gimlet.User) (gimlet.User, error) {
+					GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
 						users[u.Username()] = u
 						return u, nil
 					},
-					ClearCache: func(u gimlet.User, all bool) error {
+					ClearUserToken: func(u gimlet.User, all bool) error {
 						if all {
 							users = make(map[string]gimlet.User)
 							cache = make(map[string]gimlet.User)
@@ -144,15 +148,13 @@ func TestUserCache(t *testing.T) {
 						}
 						return nil
 					},
-				}.MakeUserCache()
+				})
 			},
 		},
 		{
-			name: "CreateOptsInMemory",
-			factory: func() UserCache {
-				return CreationOpts{
-					UserCache: NewInMemoryUserCache(ctx, time.Millisecond),
-				}.MakeUserCache()
+			name: "InMemory",
+			factory: func() (Cache, error) {
+				return NewInMemory(ctx, time.Millisecond), nil
 			},
 		},
 	} {
@@ -160,14 +162,16 @@ func TestUserCache(t *testing.T) {
 			t.Run("Impl", func(t *testing.T) {
 				for _, test := range impl.cases {
 					t.Run(test.name, func(t *testing.T) {
-						cache := impl.factory()
+						cache, err := impl.factory()
+						require.NoError(t, err)
 						test.test(t, cache)
 					})
 				}
 			})
 
 			t.Run("AddUser", func(t *testing.T) {
-				cache := impl.factory()
+				cache, err := impl.factory()
+				require.NoError(t, err)
 				const id = "username"
 				u := gimlet.NewBasicUser(id, "", "", "", "", []string{}, false, nil)
 				assert.NoError(t, cache.Add(u))
@@ -176,7 +180,8 @@ func TestUserCache(t *testing.T) {
 				assert.Equal(t, u, cu)
 			})
 			t.Run("PutGetRoundTrip", func(t *testing.T) {
-				cache := impl.factory()
+				cache, err := impl.factory()
+				require.NoError(t, err)
 				const id = "username"
 				u := gimlet.NewBasicUser(id, "", "", "", "", []string{}, false, nil)
 				token, err := cache.Put(u)
@@ -189,21 +194,24 @@ func TestUserCache(t *testing.T) {
 				assert.Equal(t, u, cu)
 			})
 			t.Run("FindErrorsForNotFound", func(t *testing.T) {
-				cache := impl.factory()
+				cache, err := impl.factory()
+				require.NoError(t, err)
 				cu, _, err := cache.Find("foo")
 				assert.Error(t, err)
 				assert.Nil(t, cu)
 			})
 			t.Run("GetCacheMiss", func(t *testing.T) {
-				cache := impl.factory()
+				cache, err := impl.factory()
+				require.NoError(t, err)
 				cu, exists, err := cache.Get("nope")
 				assert.NoError(t, err)
 				assert.False(t, exists)
 				assert.Nil(t, cu)
 			})
 			t.Run("GetOrCreateNewUser", func(t *testing.T) {
-				cache := impl.factory()
-				_, _, err := cache.Find("usr")
+				cache, err := impl.factory()
+				require.NoError(t, err)
+				_, _, err = cache.Find("usr")
 				assert.Error(t, err)
 
 				u := gimlet.NewBasicUser("usr", "", "", "", "", []string{}, false, nil)
@@ -216,8 +224,9 @@ func TestUserCache(t *testing.T) {
 				assert.NoError(t, err)
 			})
 			t.Run("GetOrCreateNewUser", func(t *testing.T) {
-				cache := impl.factory()
-				_, _, err := cache.Find("usr")
+				cache, err := impl.factory()
+				require.NoError(t, err)
+				_, _, err = cache.Find("usr")
 				assert.Error(t, err)
 
 				u := gimlet.NewBasicUser("usr", "", "", "", "", []string{}, false, nil)
@@ -230,9 +239,10 @@ func TestUserCache(t *testing.T) {
 				assert.Equal(t, u, cu)
 			})
 			t.Run("ClearUser", func(t *testing.T) {
-				cache := impl.factory()
+				cache, err := impl.factory()
+				require.NoError(t, err)
 				u := gimlet.NewBasicUser("usr", "", "", "", "", []string{}, false, nil)
-				u, err := cache.GetOrCreate(u)
+				u, err = cache.GetOrCreate(u)
 				require.NoError(t, err)
 				require.NotNil(t, u)
 				token, err := cache.Put(u)

--- a/usercache/external.go
+++ b/usercache/external.go
@@ -1,0 +1,50 @@
+package usercache
+
+import (
+	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+// ExternalOptions provides functions to inject the functionality of the user
+// cache from an external source.
+type ExternalOptions struct {
+	PutUserGetToken PutUserGetToken
+	GetUserByToken  GetUserByToken
+	ClearUserToken  ClearUserToken
+	GetUserByID     GetUserByID
+	GetOrCreateUser GetOrCreateUser
+}
+
+func (opts ExternalOptions) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(opts.PutUserGetToken == nil, "PutUserGetToken must be defined")
+	catcher.NewWhen(opts.GetUserByToken == nil, "GetUserByToken must be defined")
+	catcher.NewWhen(opts.ClearUserToken == nil, "ClearUserToken must be defined")
+	catcher.NewWhen(opts.GetUserByID == nil, "GetUserByID must be defined")
+	catcher.NewWhen(opts.GetOrCreateUser == nil, "GetOrCreateUser must be defined")
+	return catcher.Resolve()
+}
+
+// NewExternal returns an external user cache.
+func NewExternal(opts ExternalOptions) (Cache, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid cache options")
+	}
+	return &ExternalCache{Opts: opts}, nil
+}
+
+type ExternalCache struct {
+	Opts ExternalOptions
+}
+
+func (c *ExternalCache) Add(u gimlet.User) error           { _, err := c.Opts.GetOrCreateUser(u); return err }
+func (c *ExternalCache) Put(u gimlet.User) (string, error) { return c.Opts.PutUserGetToken(u) }
+func (c *ExternalCache) Get(token string) (gimlet.User, bool, error) {
+	return c.Opts.GetUserByToken(token)
+}
+func (c *ExternalCache) Clear(u gimlet.User, all bool) error       { return c.Opts.ClearUserToken(u, all) }
+func (c *ExternalCache) Find(id string) (gimlet.User, bool, error) { return c.Opts.GetUserByID(id) }
+func (c *ExternalCache) GetOrCreate(u gimlet.User) (gimlet.User, error) {
+	return c.Opts.GetOrCreateUser(u)
+}

--- a/usercache/interface.go
+++ b/usercache/interface.go
@@ -1,0 +1,40 @@
+package usercache
+
+import (
+	"github.com/evergreen-ci/gimlet"
+)
+
+// PutUserGetToken returns a new token. Updating the user's TTL should happen in
+// this function.
+type PutUserGetToken func(gimlet.User) (string, error)
+
+// GetUserByToken is a function provided by the client to retrieve cached users
+// by token.
+// It returns an error if and only if there was an error retrieving the user
+// from the cache.
+// It returns (<user>, true, nil) if the user is present in the cache and is
+// valid.
+// It returns (<user>, false, nil) if the user is present in the cache but has
+// expired.
+// It returns (nil, false, nil) if the user is not present in the cache.
+type GetUserByToken func(string) (u gimlet.User, valid bool, err error)
+
+// ClearUserToken is a function provided by the client to remove users' tokens
+// from cache. Passing true will ignore the user passed and clear all users.
+type ClearUserToken func(u gimlet.User, all bool) error
+
+// GetUserByID is a function provided by the client to get a user from persistent storage.
+type GetUserByID func(string) (u gimlet.User, valid bool, err error)
+
+// GetOrCreateUser is a function provided by the client to get a user from
+// persistent storage, or if the user does not exist, to create and save it.
+type GetOrCreateUser func(gimlet.User) (gimlet.User, error)
+
+type Cache interface {
+	Add(gimlet.User) error
+	Put(gimlet.User) (string, error)
+	Clear(gimlet.User, bool) error
+	GetOrCreate(gimlet.User) (gimlet.User, error)
+	Get(token string) (u gimlet.User, valid bool, err error)
+	Find(id string) (u gimlet.User, valid bool, err error)
+}

--- a/util/string.go
+++ b/util/string.go
@@ -1,16 +1,16 @@
-package okta
+package util
 
 import (
 	"crypto/rand"
-	"encoding/base64"
+	"encoding/hex"
 
 	"github.com/pkg/errors"
 )
 
-func randomString() (string, error) { //nolint: deadcode
+func RandomString() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
 		return "", errors.Wrap(err, "could not generate random string")
 	}
-	return base64.URLEncoding.EncodeToString(b), nil
+	return hex.EncodeToString(b), nil
 }

--- a/util/string_test.go
+++ b/util/string_test.go
@@ -1,4 +1,4 @@
-package okta
+package util
 
 import (
 	"encoding/base64"
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRandom(t *testing.T) {
+func TestRandomString(t *testing.T) {
 	prev := []string{}
 	for i := 0; i < 1000; i++ {
-		s, err := randomString()
+		s, err := RandomString()
 		require.NoError(t, err)
 		assert.Len(t, s, base64.URLEncoding.EncodedLen(32))
 		assert.NotContains(t, prev, s)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1093

This is just the refactor. Using the cache in the Okta user manager will come in a subsequent PR.
* Refactor LDAP user cache to its own package.
* Add access and refresh tokens to User interface and implementations.