### PR TITLE
MAKE-1083, MAKE-1093: use login cache and implement logout

### DIFF
--- a/okta/okta.go
+++ b/okta/okta.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"time"
-	"utils"
 
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/usercache"
@@ -35,6 +34,9 @@ type CreationOptions struct {
 
 	UserCache     usercache.Cache
 	ExternalCache *usercache.ExternalOptions
+
+	GetHTTPClient func() *http.Client
+	PutHTTPClient func(*http.Client)
 }
 
 func (opts *CreationOptions) validate() error {
@@ -50,6 +52,8 @@ func (opts *CreationOptions) validate() error {
 	catcher.NewWhen(opts.CookieDomain == "", "must specify cookie domain")
 	catcher.NewWhen(opts.SetLoginCookie == nil, "must specify function to set login cookie")
 	catcher.NewWhen(opts.UserCache == nil && opts.ExternalCache == nil, "must specify user cache")
+	catcher.NewWhen(opts.GetHTTPClient == nil, "must specify function to get HTTP clients")
+	catcher.NewWhen(opts.PutHTTPClient == nil, "must specify function to put HTTP clients")
 	if opts.CookieTTL == time.Duration(0) {
 		opts.CookieTTL = time.Hour
 	}
@@ -69,9 +73,12 @@ type userManager struct {
 	cookiePath     string
 	cookieDomain   string
 	cookieTTL      time.Duration
-	setLoginCookie string
+	setLoginCookie func(http.ResponseWriter, string)
 
 	cache usercache.Cache
+
+	getHTTPClient func() *http.Client
+	putHTTPClient func(*http.Client)
 }
 
 // NewUserManager creates a manager that connects to Okta for user
@@ -102,17 +109,13 @@ func NewUserManager(opts CreationOptions) (gimlet.UserManager, error) {
 		cookiePath:          opts.CookiePath,
 		cookieDomain:        opts.CookieDomain,
 		cookieTTL:           opts.CookieTTL,
+		getHTTPClient:       opts.GetHTTPClient,
+		putHTTPClient:       opts.PutHTTPClient,
 	}
 	return m, nil
 }
 
 func (m *userManager) GetUserByToken(ctx context.Context, token string) (gimlet.User, error) {
-	grip.Info(message.Fields{
-		"message": "kim: searching for token in cache",
-		"token":   token,
-		"cache":   fmt.Sprintf("%+v", m.cache),
-		"stack":   utils.StackTrace(),
-	})
 	user, valid, err := m.cache.Get(token)
 	if err != nil {
 		return nil, errors.Wrap(err, "problem getting cached user")
@@ -130,47 +133,48 @@ func (m *userManager) GetUserByToken(ctx context.Context, token string) (gimlet.
 
 // TODO (kim): handle reauthentication.
 func (m *userManager) reauthorizeUser(ctx context.Context, user gimlet.User) error {
-	accessToken := user.GetAccessToken()
-	catcher := grip.NewBasicCatcher()
-	catcher.Wrap(m.validateAccessToken(user.GetAccessToken()), "invalid access token")
-	if !catcher.HasErrors() {
-		userInfo, err := m.getUserInfo(ctx, accessToken)
-		catcher.Wrap(err, "could not get user info")
-		if err == nil {
-			err := m.validateGroup(userInfo.Groups)
-			catcher.Wrap(err, "could not authorize user")
-			if err == nil {
-				_, err = m.cache.Put(user)
-				catcher.Wrap(err, "could not add user to cache")
-				if err == nil {
-					return nil
-				}
-			}
-		}
-	}
-	refreshToken := user.GetRefreshToken()
-	tokens, err := m.refreshTokens(ctx, refreshToken)
-	catcher.Wrap(err, "could not refresh authorization tokens")
-	if err == nil {
-		userInfo, err := m.getUserInfo(ctx, tokens.AccessToken)
-		catcher.Wrap(err, "could not get user info")
-		if err == nil {
-			err := m.validateGroup(userInfo.Groups)
-			catcher.Wrap(err, "could not authorize user")
-			if err == nil {
-				// TODO (kim): update user tokens
-				user = makeUser(userInfo, accessToken, refreshToken)
-				_, err = m.cache.Put(user)
-				catcher.Wrap(err, "could not add user to cache")
-				if err == nil {
-					return nil
-				}
-			}
-		}
-	}
-
-	// TODO (kim): fallback - reauthenticate user.
-	return catcher.Resolve()
+	// accessToken := user.GetAccessToken()
+	// catcher := grip.NewBasicCatcher()
+	// catcher.Wrap(m.validateAccessToken(user.GetAccessToken()), "invalid access token")
+	// if !catcher.HasErrors() {
+	//     userInfo, err := m.getUserInfo(ctx, accessToken)
+	//     catcher.Wrap(err, "could not get user info")
+	//     if err == nil {
+	//         err := m.validateGroup(userInfo.Groups)
+	//         catcher.Wrap(err, "could not authorize user")
+	//         if err == nil {
+	//             _, err = m.cache.Put(user)
+	//             catcher.Wrap(err, "could not add user to cache")
+	//             if err == nil {
+	//                 return nil
+	//             }
+	//         }
+	//     }
+	// }
+	// refreshToken := user.GetRefreshToken()
+	// tokens, err := m.refreshTokens(ctx, refreshToken)
+	// catcher.Wrap(err, "could not refresh authorization tokens")
+	// if err == nil {
+	//     userInfo, err := m.getUserInfo(ctx, tokens.AccessToken)
+	//     catcher.Wrap(err, "could not get user info")
+	//     if err == nil {
+	//         err := m.validateGroup(userInfo.Groups)
+	//         catcher.Wrap(err, "could not authorize user")
+	//         if err == nil {
+	//             // TODO (kim): update user tokens
+	//             user = makeUser(userInfo, accessToken, refreshToken)
+	//             _, err = m.cache.Put(user)
+	//             catcher.Wrap(err, "could not add user to cache")
+	//             if err == nil {
+	//                 return nil
+	//             }
+	//         }
+	//     }
+	// }
+	//
+	// // TODO (kim): fallback - reauthenticate user if necessary.
+	// return catcher.Resolve()
+	return nil
 }
 
 // validateGroup checks that the user groups returned for this access token
@@ -195,16 +199,12 @@ const (
 
 func (m *userManager) GetLoginHandler(callbackURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		grip.Info(message.Fields{
-			"message":     "kim: starting login handler",
-			"context":     "GetLoginHandler",
-			"request_uri": r.RequestURI,
-			"request":     fmt.Sprintf("%+v", *r),
-		})
 		nonce, err := util.RandomString()
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
-				"message": "kim: could not get login handler",
+				"message": "could not get login handler because nonce could not be generated",
+				"auth":    "Okta",
+				"op":      "GetLoginHandler",
 			}))
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(errors.Wrap(err, "could not get login handler")))
 			return
@@ -212,7 +212,9 @@ func (m *userManager) GetLoginHandler(callbackURL string) http.HandlerFunc {
 		state, err := util.RandomString()
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
-				"message": "kim: could not get login handler",
+				"message": "could not get login handler because state could not be generated",
+				"auth":    "Okta",
+				"op":      "GetLoginHandler",
 			}))
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(errors.Wrap(err, "could not get login handler")))
 			return
@@ -227,8 +229,6 @@ func (m *userManager) GetLoginHandler(callbackURL string) http.HandlerFunc {
 		q.Add("state", state)
 		q.Add("nonce", nonce)
 
-		// TODO (kim): we should delete these cookies after the callback handler
-		// executes.
 		http.SetCookie(w, &http.Cookie{
 			Name:     nonceCookieName,
 			Path:     m.cookiePath,
@@ -245,11 +245,6 @@ func (m *userManager) GetLoginHandler(callbackURL string) http.HandlerFunc {
 			Expires:  time.Now().Add(m.cookieTTL),
 			Domain:   m.cookieDomain,
 		})
-		grip.Info(message.Fields{
-			"message": "kim: set nonce and state for authorize request",
-			"nonce":   nonce,
-			"state":   state,
-		})
 
 		http.Redirect(w, r, fmt.Sprintf("%s/oauth2/v1/authorize?%s", m.issuer, q.Encode()), http.StatusMovedPermanently)
 	}
@@ -257,12 +252,6 @@ func (m *userManager) GetLoginHandler(callbackURL string) http.HandlerFunc {
 
 func (m *userManager) GetLoginCallbackHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		grip.Info(message.Fields{
-			"message":     "kim: starting login handler callback",
-			"context":     "GetLoginCallbackHandler",
-			"request_uri": r.RequestURI,
-			"request":     fmt.Sprintf("%+v", *r),
-		})
 		nonce, state, err := getNonceAndStateCookies(r.Cookies())
 		if err != nil {
 			err = errors.Wrap(err, "failed to get Okta nonce and state from cookies")
@@ -271,23 +260,15 @@ func (m *userManager) GetLoginCallbackHandler() http.HandlerFunc {
 			return
 		}
 		checkState := r.URL.Query().Get("state")
-		grip.Info(message.Fields{
-			"message":      "kim: starting redirect callback with parameters",
-			"op":           "GetLoginCallbackHandler",
-			"auth":         "Okta",
-			"query":        fmt.Sprintf("%+v", r.URL.Query()),
-			"state_cookie": state,
-			"nonce_cookie": nonce,
-			"check_state":  checkState,
-		})
 		if state != checkState {
 			grip.Error(message.Fields{
-				"message":        "kim: mismatched states during authentication",
-				"context":        "Okta",
+				"message":        "state check failed because state from cookie did not match state from request",
 				"expected_state": state,
 				"actual_state":   checkState,
+				"op":             "GetLoginCallbackHandler",
+				"auth":           "Okta",
 			})
-			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(errors.New("mismatched states during authentication")))
+			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(errors.New("invalid state found during authentication")))
 			return
 		}
 
@@ -295,7 +276,7 @@ func (m *userManager) GetLoginCallbackHandler() http.HandlerFunc {
 			desc := r.URL.Query().Get("error_description")
 			err := fmt.Errorf("%s: %s", errCode, desc)
 			grip.Error(message.WrapError(errors.WithStack(err), message.Fields{
-				"message": "kim: failure in callback handler redirect",
+				"message": "request to callback handler redirect contained error",
 				"op":      "GetLoginCallbackHandler",
 				"auth":    "Okta",
 			}))
@@ -305,34 +286,31 @@ func (m *userManager) GetLoginCallbackHandler() http.HandlerFunc {
 
 		tokens, err := m.exchangeCodeForTokens(context.Background(), r.URL.Query().Get("code"))
 		if err != nil {
-			err = errors.Wrap(err, "could not get ID token")
+			err = errors.Wrap(err, "could not get authorization tokens")
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(err))
 			grip.Error(message.WrapError(err, message.Fields{
-				"message": "kim: failed to get token from Okta",
-				"op":      "GetLoginCallbackHandler",
-				"auth":    "Okta",
+				"message":  "failed to redeem authorization code for tokens",
+				"endpoint": "/token",
+				"op":       "GetLoginCallbackHandler",
+				"auth":     "Okta",
 			}))
 			return
 		}
 		if err := m.validateIDToken(tokens.IDToken, nonce); err != nil {
-			err = errors.Wrap(err, "could not validate ID token from Okta")
+			err = errors.Wrap(err, "invalid ID token from Okta")
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(err))
 			grip.Error(message.WrapError(err, message.Fields{
-				"message": "kim: failed to validate ID token",
+				"message": "ID token was invalid",
 				"op":      "GetLoginCallbackHandler",
 				"auth":    "Okta",
 			}))
 			return
 		}
-		grip.Info(message.Fields{
-			"message":   "kim: successfully retrieved tokens",
-			"user_info": fmt.Sprintf("%+v", *tokens),
-		})
 		if err := m.validateAccessToken(tokens.AccessToken); err != nil {
-			err = errors.Wrap(err, "could not validate access token from Okta")
+			err = errors.Wrap(err, "invalid access token from Okta")
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(err))
 			grip.Error(message.WrapError(err, message.Fields{
-				"message": "kim: failed to validate access token",
+				"message": "access token was invalid",
 				"op":      "GetLoginCallbackHandler",
 				"auth":    "Okta",
 			}))
@@ -341,26 +319,25 @@ func (m *userManager) GetLoginCallbackHandler() http.HandlerFunc {
 
 		userInfo, err := m.getUserInfo(context.Background(), tokens.AccessToken)
 		if err != nil {
-			err = errors.Wrap(err, "could not get user info from Okta")
+			err = errors.Wrap(err, "could not retrieve user info from Okta")
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(err))
 			grip.Error(message.WrapError(err, message.Fields{
-				"message": "kim: failed to get user info",
-				"op":      "GetLoginCallbackHandler",
-				"auth":    "Okta",
+				"message":  "could not authorize user due to failure to get user info",
+				"endpoint": "/userinfo",
+				"op":       "GetLoginCallbackHandler",
+				"auth":     "Okta",
 			}))
 			return
 		}
-		grip.Info(message.Fields{
-			"message":   "kim: successfully retrieved user info",
-			"user_info": fmt.Sprintf("%+v", *userInfo),
-		})
 		if err := m.validateGroup(userInfo.Groups); err != nil {
-			err = errors.Wrap(err, "could not authorize user")
+			err = errors.Wrap(err, "invalid user group")
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(err))
 			grip.Error(message.WrapError(err, message.Fields{
-				"message": "kim: failed to validate user groups",
-				"op":      "GetLoginCallbackHandler",
-				"auth":    "Okta",
+				"message":        "could not find user in expected user group",
+				"op":             "GetLoginCallbackHandler",
+				"expected_group": m.userGroup,
+				"actual_groups":  userInfo.Groups,
+				"auth":           "Okta",
 			}))
 			return
 		}
@@ -368,24 +345,16 @@ func (m *userManager) GetLoginCallbackHandler() http.HandlerFunc {
 		user := makeUser(userInfo, tokens.AccessToken, tokens.RefreshToken)
 		loginToken, err := m.cache.Put(user)
 		if err != nil {
-			err = errors.Wrap(err, "error putting user in cache")
+			err = errors.Wrap(err, "failed to cache user")
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(err))
 			grip.Error(message.WrapError(err, message.Fields{
-				"message": "kim: failed to cache user",
+				"message": "user could not be persisted in cache",
 				"op":      "GetLoginCallbackHandler",
 				"auth":    "Okta",
 			}))
 			return
 		}
 
-		grip.Info(message.Fields{
-			"message":     "kim: successfully authenticated user and validated tokens",
-			"op":          "GetLoginCallbackHandler",
-			"context":     "Okta",
-			"tokens":      fmt.Sprintf("%+v", *tokens),
-			"user_info":   fmt.Sprintf("%+v", *userInfo),
-			"login_token": loginToken,
-		})
 		m.setLoginCookie(w, loginToken)
 
 		http.Redirect(w, r, m.callbackRedirectURI, http.StatusFound)
@@ -400,19 +369,19 @@ func getNonceAndStateCookies(cookies []*http.Cookie) (nonce, state string, err e
 		if cookie.Name == nonceCookieName {
 			nonce, err = url.QueryUnescape(cookie.Value)
 			if err != nil {
-				return "", "", errors.Wrap(err, "problem reading nonce cookie")
+				return "", "", errors.Wrap(err, "found nonce cookie but failed to decode it")
 			}
 		}
 		if cookie.Name == stateCookieName {
 			state, err = url.QueryUnescape(cookie.Value)
 			if err != nil {
-				return "", "", errors.Wrap(err, "problem reading state cookie")
+				return "", "", errors.Wrap(err, "found state cookie but failed to decode it")
 			}
 		}
 	}
 	catcher := grip.NewBasicCatcher()
-	catcher.NewWhen(nonce == "", "could not get cookie for nonce")
-	catcher.NewWhen(state == "", "could not get cookie for state")
+	catcher.NewWhen(nonce == "", "could not find nonce cookie")
+	catcher.NewWhen(state == "", "could not find state cookie")
 	return nonce, state, catcher.Resolve()
 }
 
@@ -447,11 +416,8 @@ func (m *userManager) getUserInfo(ctx context.Context, accessToken string) (*use
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer "+accessToken))
 	req.Header.Add("Connection", "close")
 
-	client, err := m.client()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
+	client := m.getHTTPClient()
+	defer m.putHTTPClient(client)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "error during request for user info")
@@ -555,11 +521,11 @@ func (m *userManager) redeemTokens(ctx context.Context, query string) (*tokenRes
 	req.Header.Add("Authorization", fmt.Sprintf("Basic "+authHeader))
 	req.Header.Add("Connection", "close")
 
-	client, err := m.client()
+	client := m.getHTTPClient()
+	defer m.putHTTPClient(client)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "token request returned error")
@@ -572,13 +538,4 @@ func (m *userManager) redeemTokens(ctx context.Context, query string) (*tokenRes
 		return tokens, errors.Errorf("%s: %s", tokens.ErrorCode, tokens.ErrorDescription)
 	}
 	return tokens, nil
-}
-
-func (m *userManager) introspectToken(ctx context.Context, token, tokenType string) (*introspectResponse, error) {
-
-}
-
-type introspectResponse struct {
-	Active   boolean
-	Audience string
 }

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -18,11 +18,10 @@ import (
 
 // CreationOptions specify the options to create the manager.
 type CreationOptions struct {
-	ClientID            string
-	ClientSecret        string
-	RedirectURI         string
-	CallbackRedirectURI string
-	Issuer              string
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+	Issuer       string
 
 	UserGroup string
 
@@ -43,7 +42,6 @@ func (opts *CreationOptions) validate() error {
 	catcher.NewWhen(opts.ClientID == "", "must specify client ID")
 	catcher.NewWhen(opts.ClientSecret == "", "must specify client secret")
 	catcher.NewWhen(opts.RedirectURI == "", "must specify redirect URI")
-	catcher.NewWhen(opts.CallbackRedirectURI == "", "must specify callback redirect URI")
 	catcher.NewWhen(opts.Issuer == "", "must specify issuer")
 	catcher.NewWhen(opts.UserGroup == "", "must specify user group")
 	catcher.NewWhen(opts.CookiePath == "", "must specify cookie path")
@@ -59,11 +57,10 @@ func (opts *CreationOptions) validate() error {
 }
 
 type userManager struct {
-	clientID            string
-	clientSecret        string
-	callbackRedirectURI string
-	redirectURI         string
-	issuer              string
+	clientID     string
+	clientSecret string
+	redirectURI  string
+	issuer       string
 
 	userGroup string
 
@@ -95,18 +92,17 @@ func NewUserManager(opts CreationOptions) (gimlet.UserManager, error) {
 		}
 	}
 	m := &userManager{
-		cache:               cache,
-		clientID:            opts.ClientID,
-		clientSecret:        opts.ClientSecret,
-		redirectURI:         opts.RedirectURI,
-		callbackRedirectURI: opts.CallbackRedirectURI,
-		issuer:              opts.Issuer,
-		userGroup:           opts.UserGroup,
-		cookiePath:          opts.CookiePath,
-		cookieDomain:        opts.CookieDomain,
-		cookieTTL:           opts.CookieTTL,
-		getHTTPClient:       opts.GetHTTPClient,
-		putHTTPClient:       opts.PutHTTPClient,
+		cache:         cache,
+		clientID:      opts.ClientID,
+		clientSecret:  opts.ClientSecret,
+		redirectURI:   opts.RedirectURI,
+		issuer:        opts.Issuer,
+		userGroup:     opts.UserGroup,
+		cookiePath:    opts.CookiePath,
+		cookieDomain:  opts.CookieDomain,
+		cookieTTL:     opts.CookieTTL,
+		getHTTPClient: opts.GetHTTPClient,
+		putHTTPClient: opts.PutHTTPClient,
 	}
 	return m, nil
 }
@@ -353,7 +349,8 @@ func (m *userManager) GetLoginCallbackHandler() http.HandlerFunc {
 
 		m.setLoginCookie(w, loginToken)
 
-		http.Redirect(w, r, m.callbackRedirectURI, http.StatusFound)
+		// TODO (kim): save URI as cookie to redirect to actual requested page.
+		http.Redirect(w, r, "/", http.StatusFound)
 	}
 }
 

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -23,7 +23,6 @@ type CreationOptions struct {
 	RedirectURI         string
 	CallbackRedirectURI string
 	Issuer              string
-	Audience            string
 
 	UserGroup string
 
@@ -46,7 +45,6 @@ func (opts *CreationOptions) validate() error {
 	catcher.NewWhen(opts.RedirectURI == "", "must specify redirect URI")
 	catcher.NewWhen(opts.CallbackRedirectURI == "", "must specify callback redirect URI")
 	catcher.NewWhen(opts.Issuer == "", "must specify issuer")
-	catcher.NewWhen(opts.Audience == "", "must specify access token audience")
 	catcher.NewWhen(opts.UserGroup == "", "must specify user group")
 	catcher.NewWhen(opts.CookiePath == "", "must specify cookie path")
 	catcher.NewWhen(opts.CookieDomain == "", "must specify cookie domain")
@@ -66,7 +64,6 @@ type userManager struct {
 	callbackRedirectURI string
 	redirectURI         string
 	issuer              string
-	audience            string
 
 	userGroup string
 
@@ -101,7 +98,6 @@ func NewUserManager(opts CreationOptions) (gimlet.UserManager, error) {
 		cache:               cache,
 		clientID:            opts.ClientID,
 		clientSecret:        opts.ClientSecret,
-		audience:            opts.Audience,
 		redirectURI:         opts.RedirectURI,
 		callbackRedirectURI: opts.CallbackRedirectURI,
 		issuer:              opts.Issuer,


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1083
https://jira.mongodb.org/browse/MAKE-1093

* Use cache to implement some required functions (e.g. `GetUserByToken`, `GetUserByID`, `ClearUserToken`).
* Add functions to get/put HTTP clients.
* Add some required fields for authorizing user (`CreationOptions.UserGroup`).
* Add stubs for validating tokens (will  be done later), validate user groups before authentication passes.
* Store temp cookies and login cookies.