### PR TITLE
MAKE-1129: check for ambiguous URL scheme

### DIFF
--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -294,7 +294,7 @@ func connect(host, port string) (ldap.Client, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "problem parsing ldap url %s", fullURL)
 	}
-	if parsedURL.Scheme != "" {
+	if parsedURL.Scheme != "" && parsedURL.Scheme != host {
 		conn, err = ldap.DialURL(fullURL)
 	} else {
 		tlsConfig := &tls.Config{ServerName: host}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1129

`url.Parse()` interprets `host:port` format as having a scheme of `host` since it has a colon. We don't include a scheme in the LDAP settings, so we have to check this.