### PR TITLE
MAKE-1131: specify cookie domain

### DIFF
--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -15,17 +15,15 @@ import (
 // UserMiddlewareConfiguration is an keyed-arguments struct used to
 // produce the user manager middleware.
 type UserMiddlewareConfiguration struct {
-	SkipCookie        bool
-	SkipHeaderCheck   bool
-	HeaderUserName    string
-	HeaderKeyName     string
-	CookieName        string
-	CookiePath        string
-	CookieTTL         time.Duration
-	CookieDomain      string
-	LoginPath         string
-	LoginCallbackPath string
-	SetRedirect       func(*http.Request, string)
+	SkipCookie      bool
+	SkipHeaderCheck bool
+	HeaderUserName  string
+	HeaderKeyName   string
+	CookieName      string
+	CookiePath      string
+	CookieTTL       time.Duration
+	CookieDomain    string
+	SetRedirect     func(*http.Request, string)
 }
 
 // Validate ensures that the UserMiddlewareConfiguration is correct

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -80,6 +80,7 @@ func (umc UserMiddlewareConfiguration) ClearCookie(rw http.ResponseWriter) {
 	http.SetCookie(rw, &http.Cookie{
 		Name:   umc.CookieName,
 		Path:   umc.CookiePath,
+		Domain: umc.CookieDomain,
 		Value:  "",
 		MaxAge: -1,
 	})

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -333,6 +333,17 @@ func (m *userManager) setTemporaryCookie(w http.ResponseWriter, name, value stri
 	})
 }
 
+// unsetTemporaryCookie unsets a temporary cookie used for login.
+func (m *userManager) unsetTemporaryCookie(w http.ResponseWriter, name string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:   name,
+		Path:   m.cookiePath,
+		Domain: m.cookieDomain,
+		Value:  "",
+		MaxAge: -1,
+	})
+}
+
 func writeError(w http.ResponseWriter, err error) {
 	gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(gimlet.ErrorResponse{
 		StatusCode: http.StatusInternalServerError,
@@ -408,6 +419,9 @@ func (m *userManager) GetLoginCallbackHandler() http.HandlerFunc {
 			return
 		}
 
+		m.unsetTemporaryCookie(w, nonceCookieName)
+		m.unsetTemporaryCookie(w, stateCookieName)
+		m.unsetTemporaryCookie(w, requestURICookieName)
 		m.setLoginCookie(w, loginToken)
 
 		http.Redirect(w, r, requestURI, http.StatusFound)

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -504,7 +504,6 @@ func (m *userManager) GetUserByID(id string) (gimlet.User, error) {
 	if !valid {
 		if m.allowReauthorization {
 			if err := m.reauthorizeUser(context.Background(), user); err != nil {
-				grip.Notice(errors.Wrapf(err, "problem reauthorizing user '%s'", user.Username()))
 				return user, gimlet.ErrNeedsReauthentication
 			}
 			return user, nil


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1131

If we don't specify the login cookie domain when we clear it, it will default to this domain, which can differ from the domain the cookie is actually set for (i.e. .mongodb.com for us).

I also removed the login redirect attempt because of this cookie clearing problem, because the duplicate name cookies for staging caused the wrong cookie to always be read and login couldn't succeed without setting the cookie.