### PR TITLE
EVG-7149 reverse-proxy changes for code-server

### DIFF
--- a/app_routing.go
+++ b/app_routing.go
@@ -19,6 +19,7 @@ type APIRoute struct {
 	wrappers          []Middleware
 	version           int
 	overrideAppPrefix bool
+	isPrefix          bool
 }
 
 func (r *APIRoute) String() string {
@@ -28,13 +29,14 @@ func (r *APIRoute) String() string {
 	}
 
 	return fmt.Sprintf(
-		"r='%s%s', v='%d', methods=[%s], defined=%t, prefixOverride=%t",
+		"r='%s%s', v='%d', methods=[%s], defined=%t, prefixOverride=%t, isPrefex=%t",
 		r.prefix,
 		r.route,
 		r.version,
 		strings.Join(methods, ", "),
 		r.handler != nil,
 		r.overrideAppPrefix,
+		r.isPrefix,
 	)
 }
 
@@ -50,6 +52,15 @@ func (a *APIApp) AddRoute(r string) *APIRoute {
 	}
 
 	a.routes = append(a.routes, route)
+
+	return route
+}
+
+// AddPrefixRoute creates and registers a new route with an application
+// matching everything under the given prefix.
+func (a *APIApp) AddPrefixRoute(prefix string) *APIRoute {
+	route := a.AddRoute(prefix)
+	route.isPrefix = true
 
 	return route
 }
@@ -238,6 +249,11 @@ func (r *APIRoute) Head() *APIRoute {
 
 func (r *APIRoute) Options() *APIRoute {
 	r.methods = append(r.methods, options)
+	return r
+}
+
+func (r *APIRoute) AllMethods() *APIRoute {
+	r.methods = append(r.methods, get, put, post, del, patch, head, options)
 	return r
 }
 

--- a/app_routing_test.go
+++ b/app_routing_test.go
@@ -54,6 +54,12 @@ func (s *RoutingSuite) TestPutMethod() {
 	s.Equal(r.methods[0].String(), "PUT")
 }
 
+func (s *RoutingSuite) TestAddPrefixRoute() {
+	r := s.app.AddPrefixRoute("/work").Get()
+	s.Len(s.app.routes, 1)
+	s.True(r.isPrefix)
+}
+
 func (s *RoutingSuite) TestPrefixMethod() {
 	r := s.app.AddRoute("/work").Prefix("foo")
 	s.Len(s.app.routes, 1)

--- a/proxy.go
+++ b/proxy.go
@@ -4,9 +4,10 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
+	"regexp"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
@@ -22,7 +23,8 @@ type ProxyOptions struct {
 	RemotePrefix      string
 	StripSourcePrefix bool
 	TargetPool        []string
-	FindTarget        func(*url.URL) []string
+	FindTarget        func(*http.Request) ([]string, error)
+	RemoteScheme      string
 }
 
 // Validate checks the default configuration of a proxy configuration.
@@ -51,12 +53,35 @@ func getRandomHost(hosts []string) string {
 	}
 }
 
-func (opts *ProxyOptions) resolveTarget(u *url.URL) string {
+func (opts *ProxyOptions) resolveTarget(r *http.Request) string {
 	if opts.FindTarget == nil {
 		return ""
 	}
+	target, err := opts.FindTarget(r)
+	if err != nil {
+		return ""
+	}
+	return getRandomHost(target)
+}
 
-	return getRandomHost(opts.FindTarget(u))
+func (opts *ProxyOptions) getPath(r *http.Request) string {
+	path := r.URL.Path
+	if opts.StripSourcePrefix {
+		route := mux.CurrentRoute(r)
+		regexString, err := route.GetPathRegexp()
+		compiled, err := regexp.Compile(regexString)
+		if err != nil {
+			grip.Error(message.Fields{
+				"message": "can't strip path",
+				"regex":   regexString,
+				"URL":     r.URL.Path,
+			})
+			return path
+		}
+		path = compiled.ReplaceAllLiteralString(path, "")
+	}
+
+	return path
 }
 
 func (opts *ProxyOptions) director(req *http.Request) {
@@ -75,17 +100,17 @@ func (opts *ProxyOptions) director(req *http.Request) {
 
 	if target := opts.getHost(); target != "" {
 		req.URL.Host = target
-	} else if target := opts.resolveTarget(req.URL); target != "" {
+	} else if target := opts.resolveTarget(req); target != "" {
 		req.URL.Host = target
 	} else {
 		panic("could not resolve proxy target host")
 	}
 
-	if opts.StripSourcePrefix {
-		req.URL.Path = "/"
-	}
+	req.URL.Path = singleJoiningSlash(opts.RemotePrefix, opts.getPath(req))
 
-	req.URL.Path = singleJoiningSlash(opts.RemotePrefix, req.URL.Path)
+	if opts.RemoteScheme != "" {
+		req.URL.Scheme = opts.RemoteScheme
+	}
 }
 
 // Proxy adds a simple reverse proxy handler to the specified route,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -108,7 +108,7 @@ func TestProxyService(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "http://example.com/target/path", nil)
 		require.NoError(t, err)
 		router.ServeHTTP(nil, req)
-		assert.Equal(t, "/", req.URL.Path)
+		assert.Equal(t, "/", tp.finalRequest.URL.Path)
 	})
 	t.Run("ReplacePrefix", func(t *testing.T) {
 		tp := &testProxy{
@@ -124,14 +124,16 @@ func TestProxyService(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "http://example.com/target/path", nil)
 		require.NoError(t, err)
 		router.ServeHTTP(nil, req)
-		assert.Equal(t, "/proxy/add/", req.URL.Path)
+		assert.Equal(t, "/proxy/add/", tp.finalRequest.URL.Path)
 	})
 }
 
 type testProxy struct {
-	director func(*http.Request)
+	director     func(*http.Request)
+	finalRequest http.Request
 }
 
 func (p *testProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.director(r)
+	p.finalRequest = *r
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -2,9 +2,9 @@ package gimlet
 
 import (
 	"net/http"
-	"net/url"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,13 +32,13 @@ func TestProxyService(t *testing.T) {
 		})
 		t.Run("FindFunction", func(t *testing.T) {
 			opts := &ProxyOptions{}
-			opts.FindTarget = func(u *url.URL) []string { return nil }
+			opts.FindTarget = func(r *http.Request) ([]string, error) { return nil, nil }
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("ErrorWhenAllResolversSpecified", func(t *testing.T) {
 			opts := &ProxyOptions{
 				TargetPool: []string{"a"},
-				FindTarget: func(u *url.URL) []string { return nil },
+				FindTarget: func(r *http.Request) ([]string, error) { return nil, nil },
 			}
 			assert.Error(t, opts.Validate())
 		})
@@ -76,7 +76,7 @@ func TestProxyService(t *testing.T) {
 	t.Run("PanicWithNoHosts", func(t *testing.T) {
 		opts := &ProxyOptions{
 			TargetPool: []string{},
-			FindTarget: func(u *url.URL) []string { return nil },
+			FindTarget: func(r *http.Request) ([]string, error) { return nil, nil },
 		}
 
 		req, err := http.NewRequest(http.MethodGet, "http://example.com/target/path", nil)
@@ -96,26 +96,42 @@ func TestProxyService(t *testing.T) {
 		assert.Equal(t, "/proxy/add/target/path", req.URL.Path)
 	})
 	t.Run("StripPrefix", func(t *testing.T) {
-		opts := &ProxyOptions{
-			TargetPool:        []string{"localhost:8080"},
-			StripSourcePrefix: true,
+		tp := &testProxy{
+			director: (&ProxyOptions{
+				TargetPool:        []string{"localhost:8080"},
+				StripSourcePrefix: true,
+			}).director,
 		}
 
+		router := mux.NewRouter()
+		router.Handle("/target/path", tp)
 		req, err := http.NewRequest(http.MethodGet, "http://example.com/target/path", nil)
 		require.NoError(t, err)
-		opts.director(req)
+		router.ServeHTTP(nil, req)
 		assert.Equal(t, "/", req.URL.Path)
 	})
 	t.Run("ReplacePrefix", func(t *testing.T) {
-		opts := &ProxyOptions{
-			TargetPool:        []string{"localhost:8080"},
-			RemotePrefix:      "/proxy/add/",
-			StripSourcePrefix: true,
+		tp := &testProxy{
+			director: (&ProxyOptions{
+				TargetPool:        []string{"localhost:8080"},
+				RemotePrefix:      "/proxy/add/",
+				StripSourcePrefix: true,
+			}).director,
 		}
 
+		router := mux.NewRouter()
+		router.Handle("/target/path", tp)
 		req, err := http.NewRequest(http.MethodGet, "http://example.com/target/path", nil)
 		require.NoError(t, err)
-		opts.director(req)
-		assert.Equal(t, opts.RemotePrefix, req.URL.Path)
+		router.ServeHTTP(nil, req)
+		assert.Equal(t, "/proxy/add/", req.URL.Path)
 	})
+}
+
+type testProxy struct {
+	director func(*http.Request)
+}
+
+func (p *testProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p.director(r)
 }


### PR DESCRIPTION
- Add PrefixRoute routes that match everything beginning with a prefix.
- StripSourcePrefix (in ProxyOptions) will remove the matched prefix/route but leave the rest of the path (which should only matter for a prefix route)
- Added a remote scheme option to ProxyOptions to use a different protocol (such as http) when talking to the remote server