### PR TITLE
MAKE-1169: improve usability of basic user and manager

### DIFF
--- a/auth_basic_test.go
+++ b/auth_basic_test.go
@@ -56,7 +56,7 @@ func TestSimpleAuthenticator(t *testing.T) {
 	assert.True(auth.CheckGroupAccess(usr3, "admin"))
 
 	// check user-based role access
-	usr.(*basicUser).AccessRoles = []string{"admin", "project", "one"}
+	usr.(*BasicUser).AccessRoles = []string{"admin", "project", "one"}
 	assert.False(auth.CheckResourceAccess(usr, "admin")) // not currently authenticated
 	auth.(*simpleAuthenticator).users[usr.Username()] = usr
 	assert.True(auth.CheckResourceAccess(usr, "admin")) // now it's defined
@@ -77,7 +77,7 @@ func TestBasicAuthenticator(t *testing.T) {
 	// authenticated users are all non-nil users that have
 	// usernames
 	assert.False(auth.CheckAuthenticated(nil))
-	assert.False(auth.CheckAuthenticated(&basicUser{}))
+	assert.False(auth.CheckAuthenticated(&BasicUser{}))
 	usr := NewBasicUser("id", "name", "email", "pass", "key", "", "", []string{}, false, nil)
 	assert.True(auth.CheckAuthenticated(usr))
 

--- a/auth_basic_test.go
+++ b/auth_basic_test.go
@@ -26,7 +26,7 @@ func TestSimpleAuthenticator(t *testing.T) {
 	assert.Len(auth.(*simpleAuthenticator).users, 0)
 
 	// constructor avoids nils
-	usr := NewBasicUser("id", "name", "email", "pass", "key", "", "", []string{}, false, nil)
+	usr := NewBasicUser("id", "name", "email", "pass", "key", "", "", []string{}, nil)
 	auth = NewSimpleAuthenticator([]User{usr}, nil)
 	assert.NotNil(auth)
 	assert.NotNil(auth.(*simpleAuthenticator).groups)
@@ -38,11 +38,11 @@ func TestSimpleAuthenticator(t *testing.T) {
 	assert.True(auth.CheckAuthenticated(usr))
 
 	// a second user shouldn't validate
-	usr2 := NewBasicUser("id2", "name", "email", "pass", "key", "", "", []string{}, false, nil)
+	usr2 := NewBasicUser("id2", "name", "email", "pass", "key", "", "", []string{}, nil)
 	assert.False(auth.CheckAuthenticated(usr2))
 
-	usr3 := NewBasicUser("id3", "name", "email", "pass", "key", "", "", []string{"admin"}, false, nil)
-	usr3broken := NewBasicUser("id3", "name", "email", "pass", "yek", "", "", []string{"admin"}, false, nil)
+	usr3 := NewBasicUser("id3", "name", "email", "pass", "key", "", "", []string{"admin"}, nil)
+	usr3broken := NewBasicUser("id3", "name", "email", "pass", "yek", "", "", []string{"admin"}, nil)
 	auth = NewSimpleAuthenticator([]User{usr3}, map[string][]string{
 		"none":  []string{"_"},
 		"admin": []string{"id3"}})
@@ -56,7 +56,7 @@ func TestSimpleAuthenticator(t *testing.T) {
 	assert.True(auth.CheckGroupAccess(usr3, "admin"))
 
 	// check user-based role access
-	usr.(*BasicUser).AccessRoles = []string{"admin", "project", "one"}
+	usr.AccessRoles = []string{"admin", "project", "one"}
 	assert.False(auth.CheckResourceAccess(usr, "admin")) // not currently authenticated
 	auth.(*simpleAuthenticator).users[usr.Username()] = usr
 	assert.True(auth.CheckResourceAccess(usr, "admin")) // now it's defined
@@ -78,7 +78,7 @@ func TestBasicAuthenticator(t *testing.T) {
 	// usernames
 	assert.False(auth.CheckAuthenticated(nil))
 	assert.False(auth.CheckAuthenticated(&BasicUser{}))
-	usr := NewBasicUser("id", "name", "email", "pass", "key", "", "", []string{}, false, nil)
+	usr := NewBasicUser("id", "name", "email", "pass", "key", "", "", []string{}, nil)
 	assert.True(auth.CheckAuthenticated(usr))
 
 	auth = NewBasicAuthenticator(map[string][]string{"one": []string{"id"}}, nil)

--- a/auth_basic_test.go
+++ b/auth_basic_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleAuthenticator(t *testing.T) {
@@ -26,7 +27,9 @@ func TestSimpleAuthenticator(t *testing.T) {
 	assert.Len(auth.(*simpleAuthenticator).users, 0)
 
 	// constructor avoids nils
-	usr := NewBasicUser("id", "name", "email", "pass", "key", "", "", []string{}, nil)
+	opts, err := NewBasicUserOptions("id")
+	require.NoError(t, err)
+	usr := NewBasicUser(opts.Name("name").Email("email").Password("pass").Key("key"))
 	auth = NewSimpleAuthenticator([]User{usr}, nil)
 	assert.NotNil(auth)
 	assert.NotNil(auth.(*simpleAuthenticator).groups)
@@ -38,11 +41,15 @@ func TestSimpleAuthenticator(t *testing.T) {
 	assert.True(auth.CheckAuthenticated(usr))
 
 	// a second user shouldn't validate
-	usr2 := NewBasicUser("id2", "name", "email", "pass", "key", "", "", []string{}, nil)
+	opts2, err := NewBasicUserOptions("id2")
+	require.NoError(t, err)
+	usr2 := NewBasicUser(opts2.Name("name").Email("email").Password("pass").Key("key"))
 	assert.False(auth.CheckAuthenticated(usr2))
 
-	usr3 := NewBasicUser("id3", "name", "email", "pass", "key", "", "", []string{"admin"}, nil)
-	usr3broken := NewBasicUser("id3", "name", "email", "pass", "yek", "", "", []string{"admin"}, nil)
+	opts3, err := NewBasicUserOptions("id3")
+	require.NoError(t, err)
+	usr3 := NewBasicUser(opts3.Name("name").Email("email").Password("pass").Key("key").Roles("admin"))
+	usr3broken := NewBasicUser(opts3.Key("yek"))
 	auth = NewSimpleAuthenticator([]User{usr3}, map[string][]string{
 		"none":  []string{"_"},
 		"admin": []string{"id3"}})
@@ -78,7 +85,9 @@ func TestBasicAuthenticator(t *testing.T) {
 	// usernames
 	assert.False(auth.CheckAuthenticated(nil))
 	assert.False(auth.CheckAuthenticated(&BasicUser{}))
-	usr := NewBasicUser("id", "name", "email", "pass", "key", "", "", []string{}, nil)
+	opts, err := NewBasicUserOptions("id")
+	require.NoError(t, err)
+	usr := NewBasicUser(opts.Name("name").Email("email").Password("pass").Key("key"))
 	assert.True(auth.CheckAuthenticated(usr))
 
 	auth = NewBasicAuthenticator(map[string][]string{"one": []string{"id"}}, nil)

--- a/auth_user_basic.go
+++ b/auth_user_basic.go
@@ -5,19 +5,82 @@ import (
 	"github.com/mongodb/grip/message"
 )
 
+type BasicUserOptions struct {
+	id           string
+	name         string
+	email        string
+	password     string
+	key          string
+	accessToken  string
+	refreshToken string
+	roles        []string
+	roleManager  RoleManager
+}
+
+func NewBasicUserOptions(id string) (BasicUserOptions, error) {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(id == "", "ID must not be empty")
+	if catcher.HasErrors() {
+		return BasicUserOptions{}, catcher.Resolve()
+	}
+	return BasicUserOptions{
+		id: id,
+	}, nil
+}
+
+func (opts BasicUserOptions) Name(name string) BasicUserOptions {
+	opts.name = name
+	return opts
+}
+
+func (opts BasicUserOptions) Email(email string) BasicUserOptions {
+	opts.email = email
+	return opts
+}
+
+func (opts BasicUserOptions) Password(password string) BasicUserOptions {
+	opts.password = password
+	return opts
+}
+
+func (opts BasicUserOptions) Key(key string) BasicUserOptions {
+	opts.key = key
+	return opts
+}
+
+func (opts BasicUserOptions) AccessToken(token string) BasicUserOptions {
+	opts.accessToken = token
+	return opts
+}
+
+func (opts BasicUserOptions) RefreshToken(token string) BasicUserOptions {
+	opts.refreshToken = token
+	return opts
+}
+
+func (opts BasicUserOptions) Roles(roles ...string) BasicUserOptions {
+	opts.roles = roles
+	return opts
+}
+
+func (opts BasicUserOptions) RoleManager(rm RoleManager) BasicUserOptions {
+	opts.roleManager = rm
+	return opts
+}
+
 // NewBasicUser constructs a simple user. The underlying type has
 // serialization tags.
-func NewBasicUser(id, name, email, password, key, accessToken, refreshToken string, roles []string, rm RoleManager) *BasicUser {
+func NewBasicUser(opts BasicUserOptions) *BasicUser {
 	return &BasicUser{
-		ID:           id,
-		Name:         name,
-		EmailAddress: email,
-		Password:     password,
-		Key:          key,
-		AccessToken:  accessToken,
-		RefreshToken: refreshToken,
-		AccessRoles:  roles,
-		roleManager:  rm,
+		ID:           opts.id,
+		Name:         opts.name,
+		EmailAddress: opts.email,
+		Password:     opts.password,
+		Key:          opts.key,
+		AccessToken:  opts.accessToken,
+		RefreshToken: opts.refreshToken,
+		AccessRoles:  opts.roles,
+		roleManager:  opts.roleManager,
 	}
 }
 

--- a/auth_user_basic.go
+++ b/auth_user_basic.go
@@ -7,7 +7,7 @@ import (
 
 // NewBasicUser constructs a simple user. The underlying type has
 // serialization tags.
-func NewBasicUser(id, name, email, password, key, accessToken, refreshToken string, roles []string, invalid bool, rm RoleManager) *BasicUser {
+func NewBasicUser(id, name, email, password, key, accessToken, refreshToken string, roles []string, rm RoleManager) *BasicUser {
 	return &BasicUser{
 		ID:           id,
 		Name:         name,
@@ -17,7 +17,6 @@ func NewBasicUser(id, name, email, password, key, accessToken, refreshToken stri
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		AccessRoles:  roles,
-		Invalid:      invalid,
 		roleManager:  rm,
 	}
 }
@@ -31,8 +30,8 @@ type BasicUser struct {
 	AccessToken  string   `bson:"access_token" json:"access_token" yaml:"access_token"`
 	RefreshToken string   `bson:"refresh_token" json:"refresh_token" yaml:"refresh_token"`
 	AccessRoles  []string `bson:"roles" json:"roles" yaml:"roles"`
-	Invalid      bool     `bson:"invalid" json:"invalid" yaml:"invalid"`
 	roleManager  RoleManager
+	invalid      bool
 }
 
 func (u *BasicUser) Username() string        { return u.ID }
@@ -47,6 +46,9 @@ func (u *BasicUser) Roles() []string {
 	return out
 }
 func (u *BasicUser) HasPermission(opts PermissionOpts) bool {
+	if u.roleManager == nil {
+		return false
+	}
 	roles, err := u.roleManager.GetRoles(u.Roles())
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{

--- a/auth_user_basic.go
+++ b/auth_user_basic.go
@@ -7,8 +7,8 @@ import (
 
 // NewBasicUser constructs a simple user. The underlying type has
 // serialization tags.
-func NewBasicUser(id, name, email, password, key, accessToken, refreshToken string, roles []string, invalid bool, rm RoleManager) User {
-	return &basicUser{
+func NewBasicUser(id, name, email, password, key, accessToken, refreshToken string, roles []string, invalid bool, rm RoleManager) *BasicUser {
+	return &BasicUser{
 		ID:           id,
 		Name:         name,
 		EmailAddress: email,
@@ -22,11 +22,7 @@ func NewBasicUser(id, name, email, password, key, accessToken, refreshToken stri
 	}
 }
 
-// MakeBasicUser constructs an empty basic user structure to ease
-// serialization.
-func MakeBasicUser() User { return &basicUser{} }
-
-type basicUser struct {
+type BasicUser struct {
 	ID           string   `bson:"_id" json:"id" yaml:"id"`
 	Name         string   `bson:"name" json:"name" yaml:"name"`
 	EmailAddress string   `bson:"email" json:"email" yaml:"email"`
@@ -39,18 +35,18 @@ type basicUser struct {
 	roleManager  RoleManager
 }
 
-func (u *basicUser) Username() string        { return u.ID }
-func (u *basicUser) Email() string           { return u.EmailAddress }
-func (u *basicUser) DisplayName() string     { return u.Name }
-func (u *basicUser) GetAPIKey() string       { return u.Key }
-func (u *basicUser) GetAccessToken() string  { return u.AccessToken }
-func (u *basicUser) GetRefreshToken() string { return u.RefreshToken }
-func (u *basicUser) Roles() []string {
+func (u *BasicUser) Username() string        { return u.ID }
+func (u *BasicUser) Email() string           { return u.EmailAddress }
+func (u *BasicUser) DisplayName() string     { return u.Name }
+func (u *BasicUser) GetAPIKey() string       { return u.Key }
+func (u *BasicUser) GetAccessToken() string  { return u.AccessToken }
+func (u *BasicUser) GetRefreshToken() string { return u.RefreshToken }
+func (u *BasicUser) Roles() []string {
 	out := make([]string, len(u.AccessRoles))
 	copy(out, u.AccessRoles)
 	return out
 }
-func (u *basicUser) HasPermission(opts PermissionOpts) bool {
+func (u *BasicUser) HasPermission(opts PermissionOpts) bool {
 	roles, err := u.roleManager.GetRoles(u.Roles())
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{

--- a/auth_user_basic_test.go
+++ b/auth_user_basic_test.go
@@ -10,15 +10,13 @@ func TestBasicUserImplementation(t *testing.T) {
 	assert := assert.New(t)
 
 	// constructors
-	assert.Implements((*User)(nil), &basicUser{})
-	assert.Implements((*User)(nil), MakeBasicUser())
+	assert.Implements((*User)(nil), &BasicUser{})
 	assert.Implements((*User)(nil), NewBasicUser("", "", "", "", "", "", "", []string{}, false, nil))
-	assert.Equal(MakeBasicUser(), NewBasicUser("", "", "", "", "", "", "", nil, false, nil))
 
-	var usr *basicUser
+	var usr *BasicUser
 
 	// accessors
-	usr = &basicUser{
+	usr = &BasicUser{
 		ID:           "usrid",
 		EmailAddress: "usr@example.net",
 		Key:          "sekret",

--- a/auth_user_basic_test.go
+++ b/auth_user_basic_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBasicUserImplementation(t *testing.T) {
@@ -11,7 +12,9 @@ func TestBasicUserImplementation(t *testing.T) {
 
 	// constructors
 	assert.Implements((*User)(nil), &BasicUser{})
-	assert.Implements((*User)(nil), NewBasicUser("", "", "", "", "", "", "", []string{}, nil))
+	opts, err := NewBasicUserOptions("id")
+	require.NoError(t, err)
+	assert.Implements((*User)(nil), NewBasicUser(opts))
 
 	var usr *BasicUser
 

--- a/auth_user_basic_test.go
+++ b/auth_user_basic_test.go
@@ -11,7 +11,7 @@ func TestBasicUserImplementation(t *testing.T) {
 
 	// constructors
 	assert.Implements((*User)(nil), &BasicUser{})
-	assert.Implements((*User)(nil), NewBasicUser("", "", "", "", "", "", "", []string{}, false, nil))
+	assert.Implements((*User)(nil), NewBasicUser("", "", "", "", "", "", "", []string{}, nil))
 
 	var usr *BasicUser
 

--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -504,12 +504,12 @@ func (u *userService) getUserFromLDAP(username string) (gimlet.User, error) {
 	}
 
 	if found {
-		return makeUser(result, u.convertIDIn), nil
+		return makeUser(result, u.convertIDIn)
 	}
 	return nil, catcher.Resolve()
 }
 
-func makeUser(result *ldap.SearchResult, convertIDIn func(string) string) gimlet.User {
+func makeUser(result *ldap.SearchResult, convertIDIn func(string) string) (gimlet.User, error) {
 	var (
 		id     string
 		name   string
@@ -534,5 +534,9 @@ func makeUser(result *ldap.SearchResult, convertIDIn func(string) string) gimlet
 			groups = append(groups, entry.Values...)
 		}
 	}
-	return gimlet.NewBasicUser(id, name, email, "", "", "", "", groups, nil)
+	opts, err := gimlet.NewBasicUserOptions(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create user")
+	}
+	return gimlet.NewBasicUser(opts.Name(name).Email(email).Roles(groups...)), nil
 }

--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -534,6 +534,5 @@ func makeUser(result *ldap.SearchResult, convertIDIn func(string) string) gimlet
 			groups = append(groups, entry.Values...)
 		}
 	}
-
-	return gimlet.NewBasicUser(id, name, email, "", "", "", "", groups, false, nil)
+	return gimlet.NewBasicUser(id, name, email, "", "", "", "", groups, nil)
 }

--- a/ldap/ldap_test.go
+++ b/ldap/ldap_test.go
@@ -261,12 +261,20 @@ func mockClearUserToken(u gimlet.User, all bool) error {
 }
 
 func mockGetUserByID(id string) (gimlet.User, bool, error) {
-	u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, nil)
+	opts, err := gimlet.NewBasicUserOptions(id)
+	if err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	u := gimlet.NewBasicUser(opts)
 	return u, true, nil
 }
 
 func mockGetOrCreateUser(user gimlet.User) (gimlet.User, error) {
-	u := gimlet.NewBasicUser(user.Username(), user.DisplayName(), user.Email(), "", user.GetAPIKey(), "", "", []string{}, nil)
+	opts, err := gimlet.NewBasicUserOptions(user.Username())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	u := gimlet.NewBasicUser(opts.Name(user.DisplayName()).Email(user.Email()).Key(user.GetAPIKey()))
 	return u, nil
 }
 
@@ -744,7 +752,9 @@ func (s *LDAPSuite) TestGetUser() {
 }
 
 func (s *LDAPSuite) TestGetOrCreateUser() {
-	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil)
+	opts, err := gimlet.NewBasicUserOptions("foo")
+	s.Require().NoError(err)
+	basicUser := gimlet.NewBasicUser(opts)
 	user, err := s.um.GetOrCreateUser(basicUser)
 	s.NoError(err)
 	s.Equal("foo", user.Username())
@@ -768,7 +778,9 @@ func (s *LDAPSuite) TestLoginUsesValidPaths() {
 }
 
 func (s *LDAPSuite) TestClearUserToken() {
-	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil)
+	opts, err := gimlet.NewBasicUserOptions("foo")
+	s.Require().NoError(err)
+	basicUser := gimlet.NewBasicUser(opts)
 	user, err := s.um.GetOrCreateUser(basicUser)
 	s.Require().NoError(err)
 

--- a/ldap/ldap_test.go
+++ b/ldap/ldap_test.go
@@ -261,12 +261,12 @@ func mockClearUserToken(u gimlet.User, all bool) error {
 }
 
 func mockGetUserByID(id string) (gimlet.User, bool, error) {
-	u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, false, nil)
+	u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, nil)
 	return u, true, nil
 }
 
 func mockGetOrCreateUser(user gimlet.User) (gimlet.User, error) {
-	u := gimlet.NewBasicUser(user.Username(), user.DisplayName(), user.Email(), "", user.GetAPIKey(), "", "", []string{}, false, nil)
+	u := gimlet.NewBasicUser(user.Username(), user.DisplayName(), user.Email(), "", user.GetAPIKey(), "", "", []string{}, nil)
 	return u, nil
 }
 
@@ -744,7 +744,7 @@ func (s *LDAPSuite) TestGetUser() {
 }
 
 func (s *LDAPSuite) TestGetOrCreateUser() {
-	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil)
+	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil)
 	user, err := s.um.GetOrCreateUser(basicUser)
 	s.NoError(err)
 	s.Equal("foo", user.Username())
@@ -768,7 +768,7 @@ func (s *LDAPSuite) TestLoginUsesValidPaths() {
 }
 
 func (s *LDAPSuite) TestClearUserToken() {
-	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil)
+	basicUser := gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil)
 	user, err := s.um.GetOrCreateUser(basicUser)
 	s.Require().NoError(err)
 

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -823,7 +823,7 @@ func makeUserFromInfo(info *userInfoResponse, accessToken, refreshToken string, 
 	if id == "" {
 		return nil, errors.New("could not create user ID from email")
 	}
-	return gimlet.NewBasicUser(id, info.Name, info.Email, "", "", accessToken, refreshToken, info.Groups, false, nil), nil
+	return gimlet.NewBasicUser(id, info.Name, info.Email, "", "", accessToken, refreshToken, info.Groups, nil), nil
 }
 
 // makeUserFromIDToken returns a user based on information from an ID token.
@@ -843,5 +843,5 @@ func makeUserFromIDToken(idToken *jwtverifier.Jwt, accessToken, refreshToken str
 	if !ok {
 		return nil, errors.New("user is missing name")
 	}
-	return gimlet.NewBasicUser(id, name, email, "", "", accessToken, refreshToken, []string{}, false, nil), nil
+	return gimlet.NewBasicUser(id, name, email, "", "", accessToken, refreshToken, []string{}, nil), nil
 }

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -820,10 +820,11 @@ func makeUserFromInfo(info *userInfoResponse, accessToken, refreshToken string, 
 	if reconciliateID != nil {
 		id = reconciliateID(id)
 	}
-	if id == "" {
-		return nil, errors.New("could not create user ID from email")
+	opts, err := gimlet.NewBasicUserOptions(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create user")
 	}
-	return gimlet.NewBasicUser(id, info.Name, info.Email, "", "", accessToken, refreshToken, info.Groups, nil), nil
+	return gimlet.NewBasicUser(opts.Name(info.Name).Email(info.Email).AccessToken(accessToken).RefreshToken(refreshToken).Roles(info.Groups...)), nil
 }
 
 // makeUserFromIDToken returns a user based on information from an ID token.
@@ -843,5 +844,9 @@ func makeUserFromIDToken(idToken *jwtverifier.Jwt, accessToken, refreshToken str
 	if !ok {
 		return nil, errors.New("user is missing name")
 	}
-	return gimlet.NewBasicUser(id, name, email, "", "", accessToken, refreshToken, []string{}, nil), nil
+	opts, err := gimlet.NewBasicUserOptions(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create user")
+	}
+	return gimlet.NewBasicUser(opts.Name(name).Email(email).AccessToken(accessToken).RefreshToken(refreshToken)), nil
 }

--- a/okta/okta_test.go
+++ b/okta/okta_test.go
@@ -600,7 +600,7 @@ func TestCreateUserToken(t *testing.T) {
 }
 
 func TestGetUserByID(t *testing.T) {
-	expectedUser := gimlet.NewBasicUser("username", "name", "email", "password", "key", "access_token", "refresh_token", nil, false, nil)
+	expectedUser := gimlet.NewBasicUser("username", "name", "email", "password", "key", "access_token", "refresh_token", nil, nil)
 	for testName, testCase := range map[string]struct {
 		modifyOpts       func(CreationOptions) CreationOptions
 		shouldPass       bool
@@ -663,7 +663,7 @@ func TestGetUserByID(t *testing.T) {
 }
 
 func TestGetOrCreateUser(t *testing.T) {
-	expectedUser := gimlet.NewBasicUser("username", "name", "email", "password", "key", "access_token", "refresh_token", nil, false, nil)
+	expectedUser := gimlet.NewBasicUser("username", "name", "email", "password", "key", "access_token", "refresh_token", nil, nil)
 	for testName, testCase := range map[string]struct {
 		modifyOpts func(CreationOptions) CreationOptions
 		shouldPass bool
@@ -702,7 +702,7 @@ func TestGetOrCreateUser(t *testing.T) {
 }
 
 func TestClearUser(t *testing.T) {
-	expectedUser := gimlet.NewBasicUser("username", "name", "email", "password", "key", "access_token", "refresh_token", nil, false, nil)
+	expectedUser := gimlet.NewBasicUser("username", "name", "email", "password", "key", "access_token", "refresh_token", nil, nil)
 	for testName, testCase := range map[string]struct {
 		modifyOpts func(CreationOptions) CreationOptions
 		shouldPass bool
@@ -1110,7 +1110,7 @@ func TestReauthorization(t *testing.T) {
 			um.validateGroups = true
 
 			accessToken := "access_token"
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", accessToken, "", nil, false, nil)
+			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", accessToken, "", nil, nil)
 			_, err := um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
@@ -1141,7 +1141,7 @@ func TestReauthorization(t *testing.T) {
 		},
 		"SucceedsWithoutGroupValidation": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			refreshToken := "refresh_token"
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", "", refreshToken, nil, false, nil)
+			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", "", refreshToken, nil, nil)
 			_, err := um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
@@ -1190,7 +1190,7 @@ func TestReauthorization(t *testing.T) {
 		},
 		"FailsIfAccessTokenAndRefreshTokensMissingAndValidatingGroups": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			um.validateGroups = true
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", "", "", nil, false, nil)
+			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", "", "", nil, nil)
 
 			require.Error(t, um.ReauthorizeUser(user))
 			assert.Empty(t, s.TokenHeaders, "should not refresh tokens if refresh token missing")
@@ -1200,7 +1200,7 @@ func TestReauthorization(t *testing.T) {
 			assert.Empty(t, s.UserInfoHeaders, "should not get user info if missing access and refresh tokens")
 		},
 		"FailsIfRefreshTokensMissingAndNotValidatingGroups": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", "access_token", "", nil, false, nil)
+			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", "access_token", "", nil, nil)
 
 			require.Error(t, um.ReauthorizeUser(user))
 			assert.Empty(t, s.TokenHeaders, "should not refresh tokens if refresh token missing")
@@ -1214,7 +1214,7 @@ func TestReauthorization(t *testing.T) {
 
 			accessToken := "access_token"
 			refreshToken := "refresh_token"
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", accessToken, refreshToken, nil, false, nil)
+			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", accessToken, refreshToken, nil, nil)
 
 			_, err := um.cache.GetOrCreate(user)
 			require.NoError(t, err)
@@ -1266,7 +1266,7 @@ func TestReauthorization(t *testing.T) {
 				Scope:        "scope",
 			}
 			s.UserInfoResponse = &userInfoResponse{Name: "foo", Email: "foo@bar.com", Groups: []string{"invalid_group"}}
-			user := gimlet.NewBasicUser("id", "name", "email", "password", "key", accessToken, refreshToken, nil, false, nil)
+			user := gimlet.NewBasicUser("id", "name", "email", "password", "key", accessToken, refreshToken, nil, nil)
 			_, err := um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 

--- a/okta/okta_test.go
+++ b/okta/okta_test.go
@@ -600,7 +600,9 @@ func TestCreateUserToken(t *testing.T) {
 }
 
 func TestGetUserByID(t *testing.T) {
-	expectedUser := gimlet.NewBasicUser("username", "name", "email", "password", "key", "access_token", "refresh_token", nil, nil)
+	opts, err := gimlet.NewBasicUserOptions("username")
+	require.NoError(t, err)
+	expectedUser := gimlet.NewBasicUser(opts.Name("name").Email("email").Password("password").Key("key").AccessToken("access_token").RefreshToken("refresh_token"))
 	for testName, testCase := range map[string]struct {
 		modifyOpts       func(CreationOptions) CreationOptions
 		shouldPass       bool
@@ -663,7 +665,9 @@ func TestGetUserByID(t *testing.T) {
 }
 
 func TestGetOrCreateUser(t *testing.T) {
-	expectedUser := gimlet.NewBasicUser("username", "name", "email", "password", "key", "access_token", "refresh_token", nil, nil)
+	opts, err := gimlet.NewBasicUserOptions("username")
+	require.NoError(t, err)
+	expectedUser := gimlet.NewBasicUser(opts.Name("name").Email("email").Password("password").Key("key").AccessToken("access_token").RefreshToken("refresh_token"))
 	for testName, testCase := range map[string]struct {
 		modifyOpts func(CreationOptions) CreationOptions
 		shouldPass bool
@@ -702,7 +706,9 @@ func TestGetOrCreateUser(t *testing.T) {
 }
 
 func TestClearUser(t *testing.T) {
-	expectedUser := gimlet.NewBasicUser("username", "name", "email", "password", "key", "access_token", "refresh_token", nil, nil)
+	opts, err := gimlet.NewBasicUserOptions("username")
+	require.NoError(t, err)
+	expectedUser := gimlet.NewBasicUser(opts.Name("name").Email("email").Password("password").Key("key").AccessToken("access_token").RefreshToken("refresh_token"))
 	for testName, testCase := range map[string]struct {
 		modifyOpts func(CreationOptions) CreationOptions
 		shouldPass bool
@@ -1110,8 +1116,10 @@ func TestReauthorization(t *testing.T) {
 			um.validateGroups = true
 
 			accessToken := "access_token"
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", accessToken, "", nil, nil)
-			_, err := um.cache.GetOrCreate(user)
+			opts, err := gimlet.NewBasicUserOptions("foo")
+			require.NoError(t, err)
+			user := gimlet.NewBasicUser(opts.Name("foo").Email("foo@bar.com").Password("password").Key("key").AccessToken(accessToken))
+			_, err = um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
 			s.IntrospectResponse = &introspectResponse{Active: true}
@@ -1141,8 +1149,10 @@ func TestReauthorization(t *testing.T) {
 		},
 		"SucceedsWithoutGroupValidation": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			refreshToken := "refresh_token"
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", "", refreshToken, nil, nil)
-			_, err := um.cache.GetOrCreate(user)
+			opts, err := gimlet.NewBasicUserOptions("foo")
+			require.NoError(t, err)
+			user := gimlet.NewBasicUser(opts.Name("foo").Email("foo@bar.com").Password("password").Key("key").RefreshToken(refreshToken))
+			_, err = um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
 			newAccessToken := "new_access_token"
@@ -1190,7 +1200,9 @@ func TestReauthorization(t *testing.T) {
 		},
 		"FailsIfAccessTokenAndRefreshTokensMissingAndValidatingGroups": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			um.validateGroups = true
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", "", "", nil, nil)
+			opts, err := gimlet.NewBasicUserOptions("foo")
+			require.NoError(t, err)
+			user := gimlet.NewBasicUser(opts.Name("foo").Email("foo@bar.com").Password("password").Key("key"))
 
 			require.Error(t, um.ReauthorizeUser(user))
 			assert.Empty(t, s.TokenHeaders, "should not refresh tokens if refresh token missing")
@@ -1200,7 +1212,9 @@ func TestReauthorization(t *testing.T) {
 			assert.Empty(t, s.UserInfoHeaders, "should not get user info if missing access and refresh tokens")
 		},
 		"FailsIfRefreshTokensMissingAndNotValidatingGroups": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", "access_token", "", nil, nil)
+			opts, err := gimlet.NewBasicUserOptions("foo")
+			require.NoError(t, err)
+			user := gimlet.NewBasicUser(opts.Name("foo").Email("foo@bar.com").Password("password").Key("key").AccessToken("access_token"))
 
 			require.Error(t, um.ReauthorizeUser(user))
 			assert.Empty(t, s.TokenHeaders, "should not refresh tokens if refresh token missing")
@@ -1214,9 +1228,11 @@ func TestReauthorization(t *testing.T) {
 
 			accessToken := "access_token"
 			refreshToken := "refresh_token"
-			user := gimlet.NewBasicUser("foo", "foo", "foo@bar.com", "password", "key", accessToken, refreshToken, nil, nil)
+			opts, err := gimlet.NewBasicUserOptions("foo")
+			require.NoError(t, err)
+			user := gimlet.NewBasicUser(opts.Name("foo").Email("foo@bar.com").Password("password").Key("key").AccessToken(accessToken).RefreshToken(refreshToken))
 
-			_, err := um.cache.GetOrCreate(user)
+			_, err = um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
 			s.IntrospectResponse = &introspectResponse{Active: false}
@@ -1266,8 +1282,10 @@ func TestReauthorization(t *testing.T) {
 				Scope:        "scope",
 			}
 			s.UserInfoResponse = &userInfoResponse{Name: "foo", Email: "foo@bar.com", Groups: []string{"invalid_group"}}
-			user := gimlet.NewBasicUser("id", "name", "email", "password", "key", accessToken, refreshToken, nil, nil)
-			_, err := um.cache.GetOrCreate(user)
+			opts, err := gimlet.NewBasicUserOptions("id")
+			require.NoError(t, err)
+			user := gimlet.NewBasicUser(opts.Name("name").Email("email").Password("password").Key("key").AccessToken(accessToken).RefreshToken(refreshToken))
+			_, err = um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
 			assert.Error(t, um.ReauthorizeUser(user))

--- a/proxy.go
+++ b/proxy.go
@@ -71,7 +71,7 @@ func (opts *ProxyOptions) getPath(r *http.Request) string {
 		regexString, err := route.GetPathRegexp()
 		if err != nil {
 			grip.Error(message.Fields{
-				"message": "can't",
+				"message": "can't get route regexp",
 				"route":   route,
 				"URL":     path,
 			})

--- a/proxy.go
+++ b/proxy.go
@@ -69,6 +69,14 @@ func (opts *ProxyOptions) getPath(r *http.Request) string {
 	if opts.StripSourcePrefix {
 		route := mux.CurrentRoute(r)
 		regexString, err := route.GetPathRegexp()
+		if err != nil {
+			grip.Error(message.Fields{
+				"message": "can't",
+				"route":   route,
+				"URL":     path,
+			})
+			return path
+		}
 		compiled, err := regexp.Compile(regexString)
 		if err != nil {
 			grip.Error(message.Fields{

--- a/rolemanager/role_manager_test.go
+++ b/rolemanager/role_manager_test.go
@@ -247,7 +247,9 @@ func (s *RoleManagerSuite) TestRequiresPermissionMiddleware() {
 		permissionMiddleware.ServeHTTP(rw, r, counterFunc)
 	}
 	authenticator := gimlet.NewBasicAuthenticator(nil, nil)
-	user := gimlet.NewBasicUser("user", "name", "email", "password", "key", "access_token", "refresh_token", nil, s.m)
+	userOpts, err := gimlet.NewBasicUserOptions("user")
+	s.Require().NoError(err)
+	user := gimlet.NewBasicUser(userOpts.Name("name").Email("email").Password("password").Key("key").AccessToken("access_token").RefreshToken("refresh_token").RoleManager(s.m))
 	um, err := gimlet.NewBasicUserManager([]gimlet.BasicUser{*user}, s.m)
 	s.NoError(err)
 	authHandler := gimlet.NewAuthenticationHandler(authenticator, um)
@@ -269,7 +271,9 @@ func (s *RoleManagerSuite) TestRequiresPermissionMiddleware() {
 	s.Equal(0, counter)
 
 	// give user the right permissions
-	user = gimlet.NewBasicUser("user", "name", "email", "password", "key", "access_token", "refresh_token", []string{role1.ID}, s.m)
+	userOpts, err = gimlet.NewBasicUserOptions("user")
+	s.Require().NoError(err)
+	user = gimlet.NewBasicUser(userOpts.Name("name").Email("email").Password("password").Key("key").AccessToken("access_token").RefreshToken("refresh_token").Roles(role1.ID).RoleManager(s.m))
 	_, err = um.GetOrCreateUser(user)
 	s.NoError(err)
 	ctx = gimlet.AttachUser(req.Context(), user)

--- a/rolemanager/role_manager_test.go
+++ b/rolemanager/role_manager_test.go
@@ -247,7 +247,7 @@ func (s *RoleManagerSuite) TestRequiresPermissionMiddleware() {
 		permissionMiddleware.ServeHTTP(rw, r, counterFunc)
 	}
 	authenticator := gimlet.NewBasicAuthenticator(nil, nil)
-	user := gimlet.NewBasicUser("user", "name", "email", "password", "key", "access_token", "refresh_token", nil, false, s.m)
+	user := gimlet.NewBasicUser("user", "name", "email", "password", "key", "access_token", "refresh_token", nil, s.m)
 	um, err := gimlet.NewBasicUserManager([]gimlet.BasicUser{*user}, s.m)
 	s.NoError(err)
 	authHandler := gimlet.NewAuthenticationHandler(authenticator, um)
@@ -269,7 +269,7 @@ func (s *RoleManagerSuite) TestRequiresPermissionMiddleware() {
 	s.Equal(0, counter)
 
 	// give user the right permissions
-	user = gimlet.NewBasicUser("user", "name", "email", "password", "key", "access_token", "refresh_token", []string{role1.ID}, false, s.m)
+	user = gimlet.NewBasicUser("user", "name", "email", "password", "key", "access_token", "refresh_token", []string{role1.ID}, s.m)
 	_, err = um.GetOrCreateUser(user)
 	s.NoError(err)
 	ctx = gimlet.AttachUser(req.Context(), user)

--- a/rolemanager/role_manager_test.go
+++ b/rolemanager/role_manager_test.go
@@ -248,7 +248,7 @@ func (s *RoleManagerSuite) TestRequiresPermissionMiddleware() {
 	}
 	authenticator := gimlet.NewBasicAuthenticator(nil, nil)
 	user := gimlet.NewBasicUser("user", "name", "email", "password", "key", "access_token", "refresh_token", nil, false, s.m)
-	um, err := gimlet.NewBasicUserManager([]gimlet.User{user}, s.m)
+	um, err := gimlet.NewBasicUserManager([]gimlet.BasicUser{*user}, s.m)
 	s.NoError(err)
 	authHandler := gimlet.NewAuthenticationHandler(authenticator, um)
 	req := httptest.NewRequest("GET", "http://foo.com/bar", nil)

--- a/user_service_basic.go
+++ b/user_service_basic.go
@@ -6,35 +6,20 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
 
 // BasicUserManager implements the UserManager interface and has a list of
 // BasicUsers which is passed into the constructor.
 type BasicUserManager struct {
-	users []basicUser
+	users []BasicUser
 	rm    RoleManager
 }
 
 // NewBasicUserManager is a constructor to create a BasicUserManager from
 // a list of basic users. It requires a user created by NewBasicUser.
-func NewBasicUserManager(users []User, rm RoleManager) (UserManager, error) {
-	catcher := grip.NewBasicCatcher()
-	basicUsers := []basicUser{}
-	var bu *basicUser
-	var ok bool
-	for _, u := range users {
-		if bu, ok = u.(*basicUser); !ok {
-			catcher.Errorf("%T is not a basicUser", u)
-			continue
-		}
-		basicUsers = append(basicUsers, *bu)
-	}
-	if catcher.HasErrors() {
-		return nil, catcher.Resolve()
-	}
-	return &BasicUserManager{users: basicUsers, rm: rm}, nil
+func NewBasicUserManager(users []BasicUser, rm RoleManager) (UserManager, error) {
+	return &BasicUserManager{users: users, rm: rm}, nil
 }
 
 // GetUserByToken does a find by creating a temporary token from the index of
@@ -43,8 +28,8 @@ func NewBasicUserManager(users []User, rm RoleManager) (UserManager, error) {
 // there is a match.
 func (um *BasicUserManager) GetUserByToken(_ context.Context, token string) (User, error) {
 	for i, user := range um.users {
-		//check to see if token exists
-		possibleToken := fmt.Sprintf("%v:%v:%v", i, user.EmailAddress, md5.Sum([]byte(user.ID+user.Password)))
+		// Check to see if the token exists.
+		possibleToken := makeToken(user, i)
 		if token == possibleToken {
 			return &user, nil
 		}
@@ -60,7 +45,7 @@ func (um *BasicUserManager) CreateUserToken(username, password string) (string, 
 	for i, user := range um.users {
 		if user.ID == username && user.Password == password {
 			// return a token that is a hash of the index, user's email and username and password hashed.
-			return fmt.Sprintf("%v:%v:%v", i, user.EmailAddress, md5.Sum([]byte(user.ID+user.Password))), nil
+			return makeToken(user, i), nil
 		}
 	}
 	return "", errors.New("No valid user for the given username and password")
@@ -115,7 +100,7 @@ func (um *BasicUserManager) GetOrCreateUser(u User) (User, error) {
 		return existingUser, nil
 	}
 
-	newUser := &basicUser{
+	newUser := &BasicUser{
 		ID:           u.Username(),
 		EmailAddress: u.Email(),
 		AccessRoles:  u.Roles(),
@@ -137,4 +122,9 @@ func (b *BasicUserManager) GetGroupsForUser(userId string) ([]string, error) {
 	}
 
 	return nil, errors.Errorf("user %s not found", userId)
+}
+
+// makeToken generates a token for a user.
+func makeToken(u BasicUser, index int) string {
+	return fmt.Sprintf("%v:%v:%v", index, u.Email(), md5.Sum([]byte(u.Username()+u.Password)))
 }

--- a/user_service_basic.go
+++ b/user_service_basic.go
@@ -63,20 +63,20 @@ func (um *BasicUserManager) ReauthorizeUser(user User) error {
 	return errors.Errorf("user '%s 'not found", user.Username())
 }
 
-func (um *BasicUserManager) IsInvalid(username string) bool {
+func (um *BasicUserManager) isInvalid(username string) bool {
 	for _, user := range um.users {
 		if user.ID == username {
-			return user.Invalid
+			return user.invalid
 		}
 	}
 
 	return true
 }
 
-func (um *BasicUserManager) SetInvalid(username string, invalid bool) {
+func (um *BasicUserManager) setInvalid(username string, invalid bool) {
 	for i := range um.users {
 		if um.users[i].ID == username {
-			um.users[i].Invalid = invalid
+			um.users[i].invalid = invalid
 			return
 		}
 	}
@@ -85,7 +85,7 @@ func (um *BasicUserManager) SetInvalid(username string, invalid bool) {
 func (um *BasicUserManager) GetUserByID(id string) (User, error) {
 	for _, user := range um.users {
 		if user.ID == id {
-			if user.Invalid {
+			if user.invalid {
 				return nil, errors.Errorf("user %s not authorized!", id)
 			}
 			return &user, nil

--- a/user_service_basic_test.go
+++ b/user_service_basic_test.go
@@ -12,7 +12,7 @@ func TestBasicUserManager(t *testing.T) {
 	assert := assert.New(t)
 	assert.Implements((*UserManager)(nil), &BasicUserManager{})
 
-	u := BasicUserManager{users: []basicUser{
+	u := BasicUserManager{users: []BasicUser{
 		{
 			ID:           "foo",
 			Password:     "bar",
@@ -37,7 +37,7 @@ func TestBasicUserManager(t *testing.T) {
 	assert.Nil(u.GetLoginCallbackHandler())
 	assert.False(u.IsRedirect())
 	assert.Nil(u.ReauthorizeUser(&u.users[0]))
-	assert.NotNil(u.ReauthorizeUser(&basicUser{ID: "bar"}))
+	assert.NotNil(u.ReauthorizeUser(&BasicUser{ID: "bar"}))
 
 	user, err = u.GetUserByID("bar")
 	assert.Error(err)
@@ -49,14 +49,14 @@ func TestBasicUserManager(t *testing.T) {
 	assert.Equal("foo", user.Username())
 	assert.Equal("baz", user.Email())
 
-	newUser := &basicUser{ID: "foo"}
+	newUser := &BasicUser{ID: "foo"}
 	user, err = u.GetOrCreateUser(newUser)
 	assert.NoError(err)
 	assert.NotNil(user)
 	assert.Equal("foo", user.Username())
 	assert.Equal("baz", user.Email())
 
-	newUser = &basicUser{ID: "new_user", Password: "password", EmailAddress: "email@example.com"}
+	newUser = &BasicUser{ID: "new_user", Password: "password", EmailAddress: "email@example.com"}
 	user, err = u.GetOrCreateUser(newUser)
 	assert.NoError(err)
 	assert.NotNil(user)

--- a/user_service_basic_test.go
+++ b/user_service_basic_test.go
@@ -63,15 +63,15 @@ func TestBasicUserManager(t *testing.T) {
 	assert.Equal("new_user", user.Username())
 	assert.Equal("email@example.com", user.Email())
 
-	assert.False(u.IsInvalid(user.Username()))
-	u.SetInvalid(user.Username(), true)
-	assert.True(u.IsInvalid(user.Username()))
+	assert.False(u.isInvalid(user.Username()))
+	u.setInvalid(user.Username(), true)
+	assert.True(u.isInvalid(user.Username()))
 	returnedUser, err := u.GetUserByID(user.Username())
 	assert.Nil(returnedUser)
 	assert.Error(err)
-	u.SetInvalid(user.Username(), false)
-	assert.False(u.IsInvalid(user.Username()))
-	assert.True(u.IsInvalid("DNE"))
+	u.setInvalid(user.Username(), false)
+	assert.False(u.isInvalid(user.Username()))
+	assert.True(u.isInvalid("DNE"))
 
 	assert.Error(u.ClearUser(newUser, false))
 }

--- a/usercache/cache_test.go
+++ b/usercache/cache_test.go
@@ -21,6 +21,9 @@ func TestCache(t *testing.T) {
 		test func(*testing.T, Cache)
 	}
 
+	opts, err := gimlet.NewBasicUserOptions("foo")
+	require.NoError(t, err)
+
 	for _, impl := range []struct {
 		name    string
 		factory func() (Cache, error)
@@ -37,7 +40,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
+							user:    gimlet.NewBasicUser(opts),
 							created: time.Now().Add(-time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
@@ -50,7 +53,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
+							user:    gimlet.NewBasicUser(opts),
 							created: time.Now().Add(-time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
@@ -63,7 +66,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
+							user:    gimlet.NewBasicUser(opts),
 							created: time.Now().Add(time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
@@ -77,7 +80,7 @@ func TestCache(t *testing.T) {
 						c := cache.(*userCache)
 						c.userToToken["foo"] = "0"
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
+							user:    gimlet.NewBasicUser(opts),
 							created: time.Now().Add(time.Hour),
 						}
 						_, _, err := cache.Find("foo")
@@ -89,7 +92,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
+							user:    gimlet.NewBasicUser(opts),
 							created: time.Now().Add(-time.Hour),
 						}
 						u, exists, err := cache.Get("foo")
@@ -173,7 +176,9 @@ func TestCache(t *testing.T) {
 				cache, err := impl.factory()
 				require.NoError(t, err)
 				const id = "username"
-				u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, nil)
+				opts, err := gimlet.NewBasicUserOptions(id)
+				require.NoError(t, err)
+				u := gimlet.NewBasicUser(opts)
 				assert.NoError(t, cache.Add(u))
 				cu, _, err := cache.Find(id)
 				assert.NoError(t, err)
@@ -183,7 +188,9 @@ func TestCache(t *testing.T) {
 				cache, err := impl.factory()
 				require.NoError(t, err)
 				const id = "username"
-				u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, nil)
+				opts, err := gimlet.NewBasicUserOptions(id)
+				require.NoError(t, err)
+				u := gimlet.NewBasicUser(opts)
 				token, err := cache.Put(u)
 				assert.NoError(t, err)
 				assert.NotZero(t, token)
@@ -214,7 +221,9 @@ func TestCache(t *testing.T) {
 				_, _, err = cache.Find("usr")
 				assert.Error(t, err)
 
-				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, nil)
+				opts, err := gimlet.NewBasicUserOptions("usr")
+				require.NoError(t, err)
+				u := gimlet.NewBasicUser(opts)
 
 				cu, err := cache.GetOrCreate(u)
 				require.NoError(t, err)
@@ -229,7 +238,9 @@ func TestCache(t *testing.T) {
 				_, _, err = cache.Find("usr")
 				assert.Error(t, err)
 
-				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, nil)
+				opts, err := gimlet.NewBasicUserOptions("usr")
+				require.NoError(t, err)
+				u := gimlet.NewBasicUser(opts)
 
 				_, err = cache.Put(u)
 				require.NoError(t, err)
@@ -241,7 +252,9 @@ func TestCache(t *testing.T) {
 			t.Run("ClearUser", func(t *testing.T) {
 				cache, err := impl.factory()
 				require.NoError(t, err)
-				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, nil)
+				opts, err := gimlet.NewBasicUserOptions("usr")
+				require.NoError(t, err)
+				u := gimlet.NewBasicUser(opts)
 				u, err = cache.GetOrCreate(u)
 				require.NoError(t, err)
 				require.NotNil(t, u)

--- a/usercache/cache_test.go
+++ b/usercache/cache_test.go
@@ -37,7 +37,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
 							created: time.Now().Add(-time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
@@ -50,7 +50,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
 							created: time.Now().Add(-time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
@@ -63,7 +63,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
 							created: time.Now().Add(time.Hour),
 						}
 						assert.Len(t, c.cache, 1)
@@ -77,7 +77,7 @@ func TestCache(t *testing.T) {
 						c := cache.(*userCache)
 						c.userToToken["foo"] = "0"
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
 							created: time.Now().Add(time.Hour),
 						}
 						_, _, err := cache.Find("foo")
@@ -89,7 +89,7 @@ func TestCache(t *testing.T) {
 					test: func(t *testing.T, cache Cache) {
 						c := cache.(*userCache)
 						c.cache["foo"] = cacheValue{
-							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, false, nil),
+							user:    gimlet.NewBasicUser("foo", "", "", "", "", "", "", []string{}, nil),
 							created: time.Now().Add(-time.Hour),
 						}
 						u, exists, err := cache.Get("foo")
@@ -173,7 +173,7 @@ func TestCache(t *testing.T) {
 				cache, err := impl.factory()
 				require.NoError(t, err)
 				const id = "username"
-				u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, nil)
 				assert.NoError(t, cache.Add(u))
 				cu, _, err := cache.Find(id)
 				assert.NoError(t, err)
@@ -183,7 +183,7 @@ func TestCache(t *testing.T) {
 				cache, err := impl.factory()
 				require.NoError(t, err)
 				const id = "username"
-				u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser(id, "", "", "", "", "", "", []string{}, nil)
 				token, err := cache.Put(u)
 				assert.NoError(t, err)
 				assert.NotZero(t, token)
@@ -214,7 +214,7 @@ func TestCache(t *testing.T) {
 				_, _, err = cache.Find("usr")
 				assert.Error(t, err)
 
-				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, nil)
 
 				cu, err := cache.GetOrCreate(u)
 				require.NoError(t, err)
@@ -229,7 +229,7 @@ func TestCache(t *testing.T) {
 				_, _, err = cache.Find("usr")
 				assert.Error(t, err)
 
-				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, nil)
 
 				_, err = cache.Put(u)
 				require.NoError(t, err)
@@ -241,7 +241,7 @@ func TestCache(t *testing.T) {
 			t.Run("ClearUser", func(t *testing.T) {
 				cache, err := impl.factory()
 				require.NoError(t, err)
-				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, false, nil)
+				u := gimlet.NewBasicUser("usr", "", "", "", "", "", "", []string{}, nil)
 				u, err = cache.GetOrCreate(u)
 				require.NoError(t, err)
 				require.NotNil(t, u)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1169

* Export BasicUsers and use builder instead of long list of arguments to construct it.
* Make basic user manager accept BasicUsers as input.