### PR TITLE
MAKE-1164: implement multi user manager

### DIFF
--- a/auth_mock_test.go
+++ b/auth_mock_test.go
@@ -130,11 +130,16 @@ func (m *MockUserManager) CreateUserToken(username, password string) (string, er
 func (m *MockUserManager) GetLoginHandler(url string) http.HandlerFunc { return m.LoginHandler }
 func (m *MockUserManager) GetLoginCallbackHandler() http.HandlerFunc   { return m.LoginCallbackHandler }
 func (m *MockUserManager) IsRedirect() bool                            { return m.Redirect }
-func (m *MockUserManager) ReauthorizeUser(User) error {
+func (m *MockUserManager) ReauthorizeUser(user User) error {
 	if m.FailReauthorizeUser {
 		return errors.New("mock fail")
 	}
-	return nil
+	for _, u := range m.Users {
+		if user.Username() == u.Username() {
+			return nil
+		}
+	}
+	return errors.New("user not found")
 }
 
 func (m *MockUserManager) GetUserByID(id string) (User, error) {
@@ -161,12 +166,17 @@ func (m *MockUserManager) ClearUser(u User, all bool) error {
 	if m.FailClearUser {
 		return errors.New("mock fail")
 	}
-	return errors.New("MockUserManager does not support Clear User")
+	return nil
 }
 
 func (m *MockUserManager) GetGroupsForUser(username string) ([]string, error) {
 	if m.FailGetGroupsForUser {
 		return nil, errors.New("mock fail")
 	}
-	return nil, errors.New("not implemented")
+	for _, u := range m.Users {
+		if username == u.Username() {
+			return u.Groups, nil
+		}
+	}
+	return nil, errors.New("not found")
 }

--- a/middleware_auth_test.go
+++ b/middleware_auth_test.go
@@ -93,9 +93,7 @@ func TestAuthRequiredBehavior(t *testing.T) {
 	baduser := &MockUser{
 		ID: "bad-user",
 	}
-	usermanager := &MockUserManager{
-		TokenToUsers: map[string]User{},
-	}
+	usermanager := &MockUserManager{}
 
 	ra := NewRequireAuthHandler()
 
@@ -138,8 +136,7 @@ func TestAuthRequiredBehavior(t *testing.T) {
 	assert.Equal(0, counter)
 
 	// now set up the user
-	//
-	usermanager.TokenToUsers[authenticator.UserToken] = user
+	user.Token = authenticator.UserToken
 
 	req = httptest.NewRequest("GET", "http://localhost/bar", body)
 	rw = httptest.NewRecorder()
@@ -196,9 +193,7 @@ func TestAuthAttachWrapper(t *testing.T) {
 		UserToken:               "test",
 		CheckAuthenticatedState: map[string]bool{},
 	}
-	usermanager := &MockUserManager{
-		TokenToUsers: map[string]User{},
-	}
+	usermanager := &MockUserManager{}
 
 	ah := NewAuthenticationHandler(authenticator, usermanager)
 	assert.NotNil(ah)
@@ -248,9 +243,7 @@ func TestRoleRestrictedAccessMiddleware(t *testing.T) {
 		ID:        "test-user",
 		RoleNames: []string{"staff"},
 	}
-	usermanager := &MockUserManager{
-		TokenToUsers: map[string]User{},
-	}
+	usermanager := &MockUserManager{}
 
 	ra := NewRoleRequired("sudo")
 
@@ -293,8 +286,7 @@ func TestRoleRestrictedAccessMiddleware(t *testing.T) {
 	assert.Equal(0, counter)
 
 	// now set up the user (which is defined with the wrong role, so won't work)
-	//
-	usermanager.TokenToUsers[authenticator.UserToken] = user
+	user.Token = authenticator.UserToken
 
 	req = httptest.NewRequest("GET", "http://localhost/bar", body)
 	rw = httptest.NewRecorder()
@@ -349,14 +341,11 @@ func TestGroupAccessRequired(t *testing.T) {
 	user := &MockUser{
 		ID: "test-user",
 	}
-	usermanager := &MockUserManager{
-		TokenToUsers: map[string]User{},
-	}
+	usermanager := &MockUserManager{}
 
 	ra := NewGroupMembershipRequired("sudo")
 
 	// start without any context setup
-	//
 	req := httptest.NewRequest("GET", "http://localhost/bar", body)
 	rw := httptest.NewRecorder()
 	ra.ServeHTTP(rw, req, next)
@@ -366,7 +355,6 @@ func TestGroupAccessRequired(t *testing.T) {
 	assert.Equal(0, counter)
 
 	// try again with an authenticator...
-	//
 	req = httptest.NewRequest("GET", "http://localhost/bar", body)
 	rw = httptest.NewRecorder()
 	ctx := req.Context()
@@ -380,7 +368,6 @@ func TestGroupAccessRequired(t *testing.T) {
 	assert.Equal(0, counter)
 
 	// try with a user manager
-	//
 	req = httptest.NewRequest("GET", "http://localhost/bar", body)
 	rw = httptest.NewRecorder()
 	ctx = req.Context()
@@ -394,8 +381,7 @@ func TestGroupAccessRequired(t *testing.T) {
 	assert.Equal(0, counter)
 
 	// now set up the user (which has the wrong access defined)
-	//
-	usermanager.TokenToUsers[authenticator.UserToken] = user
+	user.Token = authenticator.UserToken
 
 	req = httptest.NewRequest("GET", "http://localhost/bar", body)
 	rw = httptest.NewRecorder()
@@ -412,7 +398,6 @@ func TestGroupAccessRequired(t *testing.T) {
 	assert.Equal(0, counter)
 
 	// make the user have the right access
-	//
 	authenticator.GroupUserMapping["test-user"] = "sudo"
 
 	req = httptest.NewRequest("GET", "http://localhost/bar", body)

--- a/middleware_auth_user_test.go
+++ b/middleware_auth_user_test.go
@@ -161,7 +161,7 @@ func TestUserMiddleware(t *testing.T) {
 	assert.Equal(http.StatusOK, rw.Code)
 
 	// test that if get-or-create fails that the op does
-	usermanager.CreateUserFails = true
+	usermanager.FailGetOrCreateUser = true
 	req, err = http.NewRequest("GET", "http://localhost/bar", body)
 	assert.NoError(err)
 	assert.NotNil(req)

--- a/middleware_auth_user_test.go
+++ b/middleware_auth_user_test.go
@@ -16,7 +16,6 @@ func TestUserMiddleware(t *testing.T) {
 	assert := assert.New(t)
 
 	// set up test fixtures
-	//
 	buf := []byte{}
 	body := bytes.NewBuffer(buf)
 	counter := 0
@@ -28,13 +27,10 @@ func TestUserMiddleware(t *testing.T) {
 		ID:     "test-user",
 		APIKey: "better",
 	}
-	usermanager := &MockUserManager{
-		TokenToUsers: map[string]User{},
-	}
+	usermanager := &MockUserManager{Users: []*MockUser{user}}
 	conf := UserMiddlewareConfiguration{}
 
 	// make sure the constructor works right
-	//
 	m := UserMiddleware(usermanager, conf)
 	assert.NotNil(m)
 	assert.Implements((*Middleware)(nil), m)
@@ -43,7 +39,6 @@ func TestUserMiddleware(t *testing.T) {
 	assert.Equal(m.(*userMiddleware).manager, usermanager)
 
 	// first test: make sure that if nothing is enabled, we pass
-	//
 	conf = UserMiddlewareConfiguration{SkipHeaderCheck: true, SkipCookie: true}
 	m = UserMiddleware(usermanager, conf)
 	assert.NotNil(m)
@@ -74,14 +69,12 @@ func TestUserMiddleware(t *testing.T) {
 	counter = 0
 
 	// Check that the header check works
-	//
 	conf = UserMiddlewareConfiguration{
 		SkipHeaderCheck: false,
 		SkipCookie:      true,
 		HeaderUserName:  "api-user",
 		HeaderKeyName:   "api-key",
 	}
-	usermanager.TokenToUsers[user.ID] = user
 	m = UserMiddleware(usermanager, conf)
 	assert.NotNil(m)
 
@@ -107,7 +100,6 @@ func TestUserMiddleware(t *testing.T) {
 	assert.Equal(http.StatusUnauthorized, rw.Code)
 
 	// check reading the cookie
-	//
 	conf = UserMiddlewareConfiguration{
 		SkipHeaderCheck: true,
 		SkipCookie:      false,
@@ -145,7 +137,7 @@ func TestUserMiddleware(t *testing.T) {
 	assert.Equal(http.StatusOK, rw.Code)
 
 	// try with something that should work
-	usermanager.TokenToUsers["42"] = user
+	user.Token = "42"
 	req, err = http.NewRequest("GET", "http://localhost/bar", body)
 	assert.NoError(err)
 	assert.NotNil(req)

--- a/user_service_multi.go
+++ b/user_service_multi.go
@@ -80,7 +80,7 @@ func (um *multiUserManager) IsRedirect() bool {
 
 func (um *multiUserManager) ReauthorizeUser(u User) error {
 	var err error
-	if err = um.tryAllManagers(func(m UserManager) (bool, error) {
+	if err = um.tryReadWriteManagers(func(m UserManager) (bool, error) {
 		err = m.ReauthorizeUser(u)
 		return err == nil, err
 	}); err != nil {

--- a/user_service_multi.go
+++ b/user_service_multi.go
@@ -156,6 +156,7 @@ func tryManagers(managerFunc func(UserManager) (success bool, err error), manage
 		if success {
 			return nil
 		}
+		catcher.Add(err)
 	}
 	return catcher.Resolve()
 }

--- a/user_service_multi.go
+++ b/user_service_multi.go
@@ -110,7 +110,7 @@ func (um *multiUserManager) GetOrCreateUser(u User) (User, error) {
 	}); err != nil {
 		return nil, errors.Wrap(err, "could not get existing or create new user")
 	}
-	return u, nil
+	return newUser, nil
 }
 
 func (um *multiUserManager) ClearUser(u User, all bool) error {

--- a/user_service_multi.go
+++ b/user_service_multi.go
@@ -9,21 +9,26 @@ import (
 )
 
 type multiUserManager struct {
-	managers []UserManager
+	primary     UserManager
+	secondaries []UserManager
 }
 
 // NewMultiUserManager multiplexes several UserManagers into a single
-// UserManager. Each method invoked on the returned UserManager is run against
-// all managers until one returns a valid result. Managers are prioritized in
-// the same order in which they are passed into this function.
-func NewMultiUserManager(managers ...UserManager) (UserManager, error) {
-	return nil, nil
+// UserManager. For write operations, UserManager methods are only invoked on
+// the primary UserManager. For read operations, the UserManager runs the method
+// against all managers until one returns a valid result. Managers are
+// prioritized in the same order in which they are passed into this function.
+func NewMultiUserManager(primary UserManager, secondaries ...UserManager) UserManager {
+	return &multiUserManager{
+		primary:     primary,
+		secondaries: secondaries,
+	}
 }
 
 func (um *multiUserManager) GetUserByToken(ctx context.Context, token string) (User, error) {
 	var u User
 	var err error
-	if err = um.tryManagers(func(m UserManager) (bool, error) {
+	if err = um.tryAllManagers(func(m UserManager) (bool, error) {
 		u, err = m.GetUserByToken(ctx, token)
 		return err == nil, err
 	}); err != nil {
@@ -33,20 +38,12 @@ func (um *multiUserManager) GetUserByToken(ctx context.Context, token string) (U
 }
 
 func (um *multiUserManager) CreateUserToken(username, password string) (string, error) {
-	var token string
-	var err error
-	if err = um.tryManagers(func(m UserManager) (bool, error) {
-		token, err = m.CreateUserToken(username, password)
-		return err == nil, err
-	}); err != nil {
-		return "", errors.Wrap(err, "failed to create user token")
-	}
-	return token, nil
+	return um.primary.CreateUserToken(username, password)
 }
 
 func (um *multiUserManager) GetLoginHandler(rootURL string) http.HandlerFunc {
 	var handler http.HandlerFunc
-	_ = um.tryManagers(func(m UserManager) (bool, error) {
+	_ = um.tryAllManagers(func(m UserManager) (bool, error) {
 		handler = m.GetLoginHandler("")
 		return handler == nil, nil
 	})
@@ -55,7 +52,7 @@ func (um *multiUserManager) GetLoginHandler(rootURL string) http.HandlerFunc {
 
 func (um *multiUserManager) GetLoginCallbackHandler() http.HandlerFunc {
 	var handler http.HandlerFunc
-	_ = um.tryManagers(func(m UserManager) (bool, error) {
+	_ = um.tryAllManagers(func(m UserManager) (bool, error) {
 		handler = m.GetLoginCallbackHandler()
 		return handler == nil, nil
 	})
@@ -64,7 +61,7 @@ func (um *multiUserManager) GetLoginCallbackHandler() http.HandlerFunc {
 
 func (um *multiUserManager) IsRedirect() bool {
 	var isRedirect bool
-	_ = um.tryManagers(func(m UserManager) (bool, error) {
+	_ = um.tryAllManagers(func(m UserManager) (bool, error) {
 		isRedirect = m.IsRedirect()
 		return isRedirect, nil
 	})
@@ -73,7 +70,7 @@ func (um *multiUserManager) IsRedirect() bool {
 
 func (um *multiUserManager) ReauthorizeUser(u User) error {
 	var err error
-	if err = um.tryManagers(func(m UserManager) (bool, error) {
+	if err = um.tryAllManagers(func(m UserManager) (bool, error) {
 		err = m.ReauthorizeUser(u)
 		return err == nil, err
 	}); err != nil {
@@ -85,7 +82,7 @@ func (um *multiUserManager) ReauthorizeUser(u User) error {
 func (um *multiUserManager) GetUserByID(id string) (User, error) {
 	var u User
 	var err error
-	if err = um.tryManagers(func(m UserManager) (bool, error) {
+	if err = um.tryAllManagers(func(m UserManager) (bool, error) {
 		u, err = m.GetUserByID(id)
 		return err == nil, err
 	}); err != nil {
@@ -95,32 +92,17 @@ func (um *multiUserManager) GetUserByID(id string) (User, error) {
 }
 
 func (um *multiUserManager) GetOrCreateUser(u User) (User, error) {
-	var newUser User
-	var err error
-	if err = um.tryManagers(func(m UserManager) (bool, error) {
-		newUser, err = m.GetOrCreateUser(u)
-		return err == nil, err
-	}); err != nil {
-		return nil, errors.Wrap(err, "could not get or create user")
-	}
-	return newUser, nil
+	return um.primary.GetOrCreateUser(u)
 }
 
 func (um *multiUserManager) ClearUser(u User, all bool) error {
-	return um.tryManagers(func(m UserManager) (bool, error) {
-		err := m.ClearUser(u, all)
-		if err == nil {
-			return false, err
-		}
-		return err == nil, err
-	})
-
+	return um.primary.ClearUser(u, all)
 }
 
 func (um *multiUserManager) GetGroupsForUser(username string) ([]string, error) {
 	var groups []string
 	var err error
-	if err = um.tryManagers(func(m UserManager) (bool, error) {
+	if err = um.tryAllManagers(func(m UserManager) (bool, error) {
 		groups, err = m.GetGroupsForUser(username)
 		return err == nil, err
 	}); err != nil {
@@ -129,12 +111,12 @@ func (um *multiUserManager) GetGroupsForUser(username string) ([]string, error) 
 	return groups, nil
 }
 
-// tryManagers runs a function on each managers until either managerFunc tells
+// tryAllManagers runs a function on each managers until either managerFunc tells
 // it to stop (which is considered success) or it has tried and failed the
 // operation on all managers.
-func (um *multiUserManager) tryManagers(managerFunc func(UserManager) (stop bool, err error)) error {
+func (um *multiUserManager) tryAllManagers(managerFunc func(UserManager) (stop bool, err error)) error {
 	catcher := grip.NewBasicCatcher()
-	for _, m := range um.managers {
+	for _, m := range append([]UserManager{um.primary}, um.secondaries...) {
 		stop, err := managerFunc(m)
 		if err == nil {
 			return nil

--- a/user_service_multi.go
+++ b/user_service_multi.go
@@ -1,0 +1,147 @@
+package gimlet
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+type multiUserManager struct {
+	managers []UserManager
+}
+
+// NewMultiUserManager multiplexes several UserManagers into a single
+// UserManager. Each method invoked on the returned UserManager is run against
+// all managers until one returns a valid result. Managers are prioritized in
+// the same order in which they are passed into this function.
+func NewMultiUserManager(managers ...UserManager) (UserManager, error) {
+	return nil, nil
+}
+
+func (um *multiUserManager) GetUserByToken(ctx context.Context, token string) (User, error) {
+	var u User
+	var err error
+	if err = um.tryManagers(func(m UserManager) (bool, error) {
+		u, err = m.GetUserByToken(ctx, token)
+		return err == nil, err
+	}); err != nil {
+		return nil, errors.Wrap(err, "could not get user by token")
+	}
+	return u, nil
+}
+
+func (um *multiUserManager) CreateUserToken(username, password string) (string, error) {
+	var token string
+	var err error
+	if err = um.tryManagers(func(m UserManager) (bool, error) {
+		token, err = m.CreateUserToken(username, password)
+		return err == nil, err
+	}); err != nil {
+		return "", errors.Wrap(err, "failed to create user token")
+	}
+	return token, nil
+}
+
+func (um *multiUserManager) GetLoginHandler(rootURL string) http.HandlerFunc {
+	var handler http.HandlerFunc
+	_ = um.tryManagers(func(m UserManager) (bool, error) {
+		handler = m.GetLoginHandler("")
+		return handler == nil, nil
+	})
+	return handler
+}
+
+func (um *multiUserManager) GetLoginCallbackHandler() http.HandlerFunc {
+	var handler http.HandlerFunc
+	_ = um.tryManagers(func(m UserManager) (bool, error) {
+		handler = m.GetLoginCallbackHandler()
+		return handler == nil, nil
+	})
+	return handler
+}
+
+func (um *multiUserManager) IsRedirect() bool {
+	var isRedirect bool
+	_ = um.tryManagers(func(m UserManager) (bool, error) {
+		isRedirect = m.IsRedirect()
+		return isRedirect, nil
+	})
+	return isRedirect
+}
+
+func (um *multiUserManager) ReauthorizeUser(u User) error {
+	var err error
+	if err = um.tryManagers(func(m UserManager) (bool, error) {
+		err = m.ReauthorizeUser(u)
+		return err == nil, err
+	}); err != nil {
+		return errors.Wrap(err, "could not reauthorize user")
+	}
+	return nil
+}
+
+func (um *multiUserManager) GetUserByID(id string) (User, error) {
+	var u User
+	var err error
+	if err = um.tryManagers(func(m UserManager) (bool, error) {
+		u, err = m.GetUserByID(id)
+		return err == nil, err
+	}); err != nil {
+		return nil, errors.Wrap(err, "could not get user by ID")
+	}
+	return u, nil
+}
+
+func (um *multiUserManager) GetOrCreateUser(u User) (User, error) {
+	var newUser User
+	var err error
+	if err = um.tryManagers(func(m UserManager) (bool, error) {
+		newUser, err = m.GetOrCreateUser(u)
+		return err == nil, err
+	}); err != nil {
+		return nil, errors.Wrap(err, "could not get or create user")
+	}
+	return newUser, nil
+}
+
+func (um *multiUserManager) ClearUser(u User, all bool) error {
+	return um.tryManagers(func(m UserManager) (bool, error) {
+		err := m.ClearUser(u, all)
+		if err == nil {
+			return false, err
+		}
+		return err == nil, err
+	})
+
+}
+
+func (um *multiUserManager) GetGroupsForUser(username string) ([]string, error) {
+	var groups []string
+	var err error
+	if err = um.tryManagers(func(m UserManager) (bool, error) {
+		groups, err = m.GetGroupsForUser(username)
+		return err == nil, err
+	}); err != nil {
+		return nil, errors.Wrap(err, "could not get groups for user")
+	}
+	return groups, nil
+}
+
+// tryManagers runs a function on each managers until either managerFunc tells
+// it to stop (which is considered success) or it has tried and failed the
+// operation on all managers.
+func (um *multiUserManager) tryManagers(managerFunc func(UserManager) (stop bool, err error)) error {
+	catcher := grip.NewBasicCatcher()
+	for _, m := range um.managers {
+		stop, err := managerFunc(m)
+		if err == nil {
+			return nil
+		}
+		if stop {
+			return nil
+		}
+	}
+	return catcher.Resolve()
+}

--- a/user_service_multi_test.go
+++ b/user_service_multi_test.go
@@ -1,26 +1,272 @@
 package gimlet
 
-// func TestMultiUserManager(t *testing.T) {
-//     for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){
-//         "GetUserByToken": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
-//
-//         },
-//         // "": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){},
-//         // "": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){},
-//         // "": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){},
-//         // "": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){},
-//     } {
-//         t.Run(testName, func(t *testing.T) {
-//             ctx, cancel := context.WithCancel(context.Background())
-//             defer cancel()
-//             readWrite := &MockUserManager{
-//                 // TokenToUsers: map[string]User{
-//                 //     ""
-//                 // }
-//             }
-//             readOnly := &MockUserManager{}
-//             um := NewMultiUserManager([]UserManager{}, []UserManager{})
-//             testCase(ctx, t, um, readWrite, readOnly)
-//         })
-//     }
-// }
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiUserManager(t *testing.T) {
+	makeUser := func(n int) *MockUser {
+		ns := fmt.Sprint(n)
+		return &MockUser{
+			ID:       "user" + ns,
+			Password: "password" + ns,
+			Token:    "token" + ns,
+			Groups:   []string{"group" + ns},
+		}
+	}
+	readWrite := func() *MockUserManager {
+		return &MockUserManager{
+			Users:                []*MockUser{makeUser(1), makeUser(2)},
+			Redirect:             true,
+			LoginHandler:         func(w http.ResponseWriter, r *http.Request) {},
+			LoginCallbackHandler: func(w http.ResponseWriter, r *http.Request) {},
+		}
+	}
+	readOnly := func() *MockUserManager {
+		return &MockUserManager{
+			Users:                []*MockUser{makeUser(1), makeUser(3)},
+			Redirect:             true,
+			LoginHandler:         func(http.ResponseWriter, *http.Request) {},
+			LoginCallbackHandler: func(http.ResponseWriter, *http.Request) {},
+		}
+	}
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager){
+		"GetUserByTokenSucceeds": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			u, err := um.GetUserByToken(ctx, makeUser(2).Token)
+			require.NoError(t, err)
+			assert.Equal(t, makeUser(2).Username(), u.Username())
+		},
+		"GetUserByTokenFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailGetUserByToken = true
+			u, err := um.GetUserByToken(ctx, makeUser(2).Token)
+			assert.Error(t, err)
+			assert.Nil(t, u)
+		},
+		"GetUserByTokenNonexistentFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			u, err := um.GetUserByToken(ctx, makeUser(4).Token)
+			assert.Error(t, err)
+			assert.Nil(t, u)
+		},
+		"GetUserByTokenTriesAllManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailGetUserByToken = true
+			u, err := um.GetUserByToken(ctx, makeUser(1).Token)
+			require.NoError(t, err)
+			assert.Equal(t, makeUser(1).Username(), u.Username())
+		},
+		"GetUserByTokenPrioritizesReadWriteManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readOnly.FailGetUserByToken = true
+			u, err := um.GetUserByToken(ctx, makeUser(1).Token)
+			require.NoError(t, err)
+			assert.Equal(t, makeUser(1).Username(), u.Username())
+		},
+		"GetUserByTokenFailsIfAllManagersFail": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailGetUserByToken = true
+			readOnly.FailGetUserByToken = true
+			u, err := um.GetUserByToken(ctx, makeUser(1).Token)
+			assert.Error(t, err)
+			assert.Nil(t, u)
+		},
+		"GetUserByIDSucceeds": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			u, err := um.GetUserByID(makeUser(2).Username())
+			require.NoError(t, err)
+			assert.Equal(t, makeUser(2).Username(), u.Username())
+		},
+		"GetUserByIDFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailGetUserByID = true
+			u, err := um.GetUserByID(makeUser(2).Username())
+			assert.Error(t, err)
+			assert.Nil(t, u)
+		},
+		"GetUserByIDNonexistentFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			u, err := um.GetUserByID(makeUser(4).Username())
+			assert.Error(t, err)
+			assert.Nil(t, u)
+		},
+		"GetUserByIDTriesAllManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailGetUserByID = true
+			u, err := um.GetUserByID(makeUser(1).Username())
+			require.NoError(t, err)
+			assert.Equal(t, makeUser(1).Username(), u.Username())
+		},
+		"GetUserByIDPrioritizesReadWriteManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readOnly.FailGetUserByID = true
+			u, err := um.GetUserByID(makeUser(1).Username())
+			require.NoError(t, err)
+			assert.Equal(t, makeUser(1).Username(), u.Username())
+		},
+		"GetUserByIDFailsIfAllManagersFail": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailGetUserByID = true
+			readOnly.FailGetUserByID = true
+			u, err := um.GetUserByID(makeUser(1).Username())
+			assert.Error(t, err)
+			assert.Nil(t, u)
+		},
+		"GetGroupsForUserSucceeds": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			groups, err := um.GetGroupsForUser(makeUser(2).Username())
+			require.NoError(t, err)
+			assert.Equal(t, makeUser(2).Groups, groups)
+		},
+		"GetGroupsForUserFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailGetGroupsForUser = true
+			groups, err := um.GetGroupsForUser(makeUser(2).Username())
+			assert.Error(t, err)
+			assert.Empty(t, groups)
+		},
+		"GetGroupsForUserNonexistentFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			groups, err := um.GetGroupsForUser(makeUser(4).Username())
+			assert.Error(t, err)
+			assert.Empty(t, groups)
+		},
+		"GetGroupsForUserTriesAllManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailGetGroupsForUser = true
+			groups, err := um.GetGroupsForUser(makeUser(1).Username())
+			require.NoError(t, err)
+			assert.Equal(t, makeUser(1).Groups, groups)
+		},
+		"GetGroupsForUserPrioritizesReadWriteManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readOnly.FailGetGroupsForUser = true
+			groups, err := um.GetGroupsForUser(makeUser(1).Username())
+			require.NoError(t, err)
+			assert.Equal(t, makeUser(1).Groups, groups)
+		},
+		"GetGroupsForUserFailsIfAllManagersFail": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailGetGroupsForUser = true
+			readOnly.FailGetGroupsForUser = true
+			u, err := um.GetGroupsForUser(makeUser(1).Username())
+			assert.Error(t, err)
+			assert.Empty(t, u)
+		},
+		"ReauthorizeUserSucceeds": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			assert.NoError(t, um.ReauthorizeUser(makeUser(2)))
+		},
+		"ReauthorizeUserFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailReauthorizeUser = true
+			assert.Error(t, um.ReauthorizeUser(makeUser(2)))
+		},
+		"ReauthorizeUserNonexistentFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			assert.Error(t, um.ReauthorizeUser(makeUser(4)))
+		},
+		"ReauthorizeUserTriesAllManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailReauthorizeUser = true
+			assert.NoError(t, um.ReauthorizeUser(makeUser(1)))
+		},
+		"ReauthorizeUserPrioritizesReadWriteManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readOnly.FailReauthorizeUser = true
+			assert.NoError(t, um.ReauthorizeUser(makeUser(1)))
+		},
+		"ReauthorizeUserFailsIfAllManagersFail": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.FailReauthorizeUser = true
+			readOnly.FailReauthorizeUser = true
+			assert.Error(t, um.ReauthorizeUser(makeUser(1)))
+		},
+		"CreateUserTokenSucceeds": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			user := makeUser(4)
+			token, err := um.CreateUserToken(user.Username(), user.Password)
+			require.NoError(t, err)
+			assert.Equal(t, mockUserToken(user.Username(), user.Password), token)
+		},
+		"CreateUserTokenIgnoresReadOnlyUserManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			user := makeUser(4)
+			readOnly.FailCreateUserToken = true
+			token, err := um.CreateUserToken(user.Username(), user.Password)
+			require.NoError(t, err)
+			assert.Equal(t, mockUserToken(user.Username(), user.Password), token)
+		},
+		"CreateUserTokenFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			user := makeUser(4)
+			readWrite.FailCreateUserToken = true
+			token, err := um.CreateUserToken(user.Username(), user.Password)
+			assert.Error(t, err)
+			assert.Empty(t, token)
+		},
+		"GetOrCreateUserSucceeds": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			user := makeUser(4)
+			u, err := um.GetOrCreateUser(user)
+			require.NoError(t, err)
+			assert.Equal(t, user.Username(), u.Username())
+		},
+		"GetOrCreateUserIgnoresReadOnlyUserManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			user := makeUser(4)
+			readOnly.FailGetOrCreateUser = true
+			u, err := um.GetOrCreateUser(user)
+			require.NoError(t, err)
+			assert.Equal(t, user.Username(), u.Username())
+		},
+		"GetOrCreateUserFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			user := makeUser(4)
+			readWrite.FailGetOrCreateUser = true
+			u, err := um.GetOrCreateUser(user)
+			assert.Error(t, err)
+			assert.Nil(t, u)
+		},
+		"ClearUserSucceeds": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			user := makeUser(4)
+			assert.NoError(t, um.ClearUser(user, false))
+		},
+		"ClearUserIgnoresReadOnlyUserManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			user := makeUser(4)
+			readOnly.FailClearUser = true
+			assert.NoError(t, um.ClearUser(user, false))
+		},
+		"ClearUserFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			user := makeUser(4)
+			readWrite.FailClearUser = true
+			assert.Error(t, um.ClearUser(user, false))
+		},
+		"GetLoginHandlerSucceeds": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			h := um.GetLoginHandler("")
+			assert.NotNil(t, h)
+		},
+		"GetLoginHandlerIgnoresReadOnlyUserManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readOnly.LoginHandler = nil
+			h := um.GetLoginHandler("")
+			assert.NotNil(t, h)
+		},
+		"GetLoginHandlerNil": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.LoginHandler = nil
+			h := um.GetLoginHandler("")
+			assert.Nil(t, h)
+		},
+		"GetLoginCallbackHandlerSucceeds": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			h := um.GetLoginCallbackHandler()
+			assert.NotNil(t, h)
+		},
+		"GetLoginCallbackHandlerIgnoresReadOnlyUserManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readOnly.LoginCallbackHandler = nil
+			h := um.GetLoginCallbackHandler()
+			assert.NotNil(t, h)
+		},
+		"GetLoginCallbackHandlerFails": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.LoginCallbackHandler = nil
+			h := um.GetLoginCallbackHandler()
+			assert.Nil(t, h)
+		},
+		"IsRedirectTrue": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			assert.True(t, um.IsRedirect())
+		},
+		"IsRedirectIgnoresReadOnlyUserManagers": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readOnly.Redirect = false
+			assert.True(t, um.IsRedirect())
+		},
+		"IsRedirectFalse": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+			readWrite.Redirect = false
+			assert.False(t, um.IsRedirect())
+		},
+		// "": func(ctx context.Context, t *testing.T, um UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			rw := readWrite()
+			ro := readOnly()
+			um := NewMultiUserManager([]UserManager{rw}, []UserManager{ro})
+			testCase(ctx, t, um, rw, ro)
+		})
+	}
+}

--- a/user_service_multi_test.go
+++ b/user_service_multi_test.go
@@ -1,0 +1,7 @@
+package gimlet
+
+import "testing"
+
+func TestMultiUserManager(t *testing.T) {
+
+}

--- a/user_service_multi_test.go
+++ b/user_service_multi_test.go
@@ -1,7 +1,26 @@
 package gimlet
 
-import "testing"
-
-func TestMultiUserManager(t *testing.T) {
-
-}
+// func TestMultiUserManager(t *testing.T) {
+//     for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){
+//         "GetUserByToken": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager) {
+//
+//         },
+//         // "": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){},
+//         // "": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){},
+//         // "": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){},
+//         // "": func(ctx context.Context, t *testing.T, um gimlet.UserManager, readWrite *MockUserManager, readOnly *MockUserManager){},
+//     } {
+//         t.Run(testName, func(t *testing.T) {
+//             ctx, cancel := context.WithCancel(context.Background())
+//             defer cancel()
+//             readWrite := &MockUserManager{
+//                 // TokenToUsers: map[string]User{
+//                 //     ""
+//                 // }
+//             }
+//             readOnly := &MockUserManager{}
+//             um := NewMultiUserManager([]UserManager{}, []UserManager{})
+//             testCase(ctx, t, um, readWrite, readOnly)
+//         })
+//     }
+// }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1164

The plan for Evergreen is to have the Okta user manager be the real manager and the basic user manager will be read-only so we can't add/remove/reauthorize users via the UserManager interface.

* Add multi user manager that performs the op until it reaches the first success.
    * Read-write managers can perform all UserManager operations.
    * Read-only managers can get users by id/token, but can't create/delete/reauthorize users.