### PR TITLE
EVG-8182 Log http.ErrAbortHandler errors at a lower level

### DIFF
--- a/middleware_grip.go
+++ b/middleware_grip.go
@@ -170,7 +170,7 @@ func (l *appRecoveryLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, n
 	defer func() {
 		if err := recover(); err != nil {
 			if rw.Header().Get("Content-Type") == "" {
-				rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 			}
 			rw.WriteHeader(http.StatusInternalServerError)
 


### PR DESCRIPTION
The http.ErrAbortHandler is a [sentinel error](https://github.com/golang/go/blob/844bf11ecd362e50e62a81c93aa2ac602de59adc/src/net/http/server.go#L1742) to suppress go server logging of the error. 
Since our middleware recovers this panic in the HandlerFunc before it makes it back up to the server we should at least log at a lower level.