### PR TITLE
EVG-12629: return the error message from Okta server

### DIFF
--- a/okta/okta.go
+++ b/okta/okta.go
@@ -627,7 +627,7 @@ func (m *userManager) validateAccessToken(token string) error {
 	if err != nil {
 		return errors.Wrap(err, "could not check if token is valid")
 	}
-	if !info.Active || int64(info.ExpiresUnix) <= time.Now().Unix() {
+	if !info.Active || info.ExpiresUnix != 0 && int64(info.ExpiresUnix) <= time.Now().Unix() {
 		return errors.New("access token is inactive, so authorization is not possible")
 	}
 	return nil

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -237,10 +237,10 @@ func (m *userManager) ReauthorizeUser(user gimlet.User) error {
 	refreshToken := user.GetRefreshToken()
 	catcher := grip.NewBasicCatcher()
 
-	// This is just an optimization to use the access token without needing to
-	// make a request to refresh the tokens. Validating the groups may fail if
-	// the access token is expired, in which case it has to refresh the access
-	// token and try again.
+	// This is just an optimization to try using the access token without
+	// needing to make a request to refresh the tokens. Validating the groups
+	// may fail if the access token is expired, in which case it has to refresh
+	// the access token and try again.
 	if m.validateGroups {
 		accessToken := user.GetAccessToken()
 		if accessToken == "" {

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -238,6 +237,10 @@ func (m *userManager) ReauthorizeUser(user gimlet.User) error {
 	refreshToken := user.GetRefreshToken()
 	catcher := grip.NewBasicCatcher()
 
+	// This is just an optimization to use the access token without needing to
+	// make a request to refresh the tokens. Validating the groups may fail if
+	// the access token is expired, in which case it has to refresh the access
+	// token and try again.
 	if m.validateGroups {
 		accessToken := user.GetAccessToken()
 		if accessToken == "" {
@@ -250,11 +253,10 @@ func (m *userManager) ReauthorizeUser(user gimlet.User) error {
 		}
 	}
 
+	// Refresh the tokens and reauthenticate.
 	if refreshToken == "" {
 		return errors.Errorf("user '%s' cannot refresh tokens because refresh token is missing", user.Username())
 	}
-	// kim: TODO: validate own token using introspect endpoint and see what it
-	// returns.
 	tokenInfo, err := m.getTokenInfo(context.Background(), refreshToken, "refresh_token")
 	if err != nil {
 		return errors.Wrapf(err, "introspecting refresh token for user '%s'", user.Username())
@@ -641,14 +643,34 @@ func (m *userManager) validateAccessToken(token string) error {
 
 // tokenResponse represents a response received from the token endpoint.
 type tokenResponse struct {
-	AccessToken      string `json:"access_token,omitempty"`
-	IDToken          string `json:"id_token,omitempty"`
-	RefreshToken     string `json:"refresh_token,omitempty"`
-	TokenType        string `json:"token_type,omitempty"`
-	ExpiresIn        int    `json:"expires_in,omitempty"`
-	Scope            string `json:"scope,omitempty"`
+	responseError
+	AccessToken  string `json:"access_token,omitempty"`
+	IDToken      string `json:"id_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+// responseError is the common section of the Okta endpoint responses that
+// contains error information.
+type responseError struct {
 	ErrorCode        string `json:"error,omitempty"`
 	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+func (re *responseError) Error() string {
+	var msg string
+	if re.ErrorCode != "" {
+		msg += re.ErrorCode
+		if re.ErrorDescription != "" {
+			msg += ": "
+		}
+	}
+	if re.ErrorDescription != "" {
+		msg += re.ErrorDescription
+	}
+	return msg
 }
 
 // exchangeCodeForTokens exchanges the given code to redeem tokens from the
@@ -704,38 +726,16 @@ func (m *userManager) redeemTokens(ctx context.Context, query string) (*tokenRes
 	if err != nil {
 		return nil, errors.Wrap(err, "request to redeem token returned error")
 	}
-	if resp.StatusCode != http.StatusOK {
-		catcher := grip.NewBasicCatcher()
-		catcher.Errorf("received unexpected status code %d", resp.StatusCode)
-		body, err := ioutil.ReadAll(resp.Body)
-		catcher.Wrap(resp.Body.Close(), "error closing response body")
-		catcher.Wrap(err, "could not read error response body")
-		grip.ErrorWhen(len(body) != 0, message.Fields{
-			"message":     "received non-OK status code from server",
-			"status_code": resp.StatusCode,
-			"body":        string(body),
-			"endpoint":    "token",
-			"context":     "Okta user manager",
-		})
-		return nil, catcher.Resolve()
-	}
 	tokens := &tokenResponse{}
-	if err := gimlet.GetJSONUnlimited(resp.Body, tokens); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if tokens.ErrorCode != "" {
-		return tokens, errors.Errorf("%s: %s", tokens.ErrorCode, tokens.ErrorDescription)
-	}
-	return tokens, nil
+	return tokens, readResp(resp, tokens)
 }
 
 // userInfo represents a response received from the userinfo endpoint.
 type userInfoResponse struct {
-	Name             string   `json:"name"`
-	Email            string   `json:"email"`
-	Groups           []string `json:"groups"`
-	ErrorCode        string   `json:"error,omitempty"`
-	ErrorDescription string   `json:"error_description,omitempty"`
+	responseError
+	Name   string   `json:"name"`
+	Email  string   `json:"email"`
+	Groups []string `json:"groups"`
 }
 
 // getUserInfo uses the access token to retrieve user information from the
@@ -762,44 +762,31 @@ func (m *userManager) getUserInfo(ctx context.Context, accessToken string) (*use
 	if err != nil {
 		return nil, errors.Wrap(err, "error during request for user info")
 	}
-	if resp.StatusCode != http.StatusOK {
-		catcher := grip.NewBasicCatcher()
-		catcher.Errorf("received unexpected status code %d", resp.StatusCode)
-		catcher.Wrap(resp.Body.Close(), "error closing response body")
-		return nil, catcher.Resolve()
-	}
 	userInfo := &userInfoResponse{}
-	if err := gimlet.GetJSONUnlimited(resp.Body, userInfo); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if userInfo.ErrorCode != "" {
-		return userInfo, errors.Errorf("%s: %s", userInfo.ErrorCode, userInfo.ErrorDescription)
-	}
-	return userInfo, nil
+	return userInfo, readResp(resp, userInfo)
 }
 
 // introspectResponse represents a response received from the introspect
 // endpoint.
 type introspectResponse struct {
-	Active           bool   `json:"active,omitempty"`
-	Audience         string `json:"aud,omitempty"`
-	ClientID         string `json:"client_id"`
-	DeviceID         string `json:"device_id"`
-	ExpiresUnix      int    `json:"exp"`
-	IssuedAtUnix     int    `json:"iat"`
-	Issuer           string `json:"iss"`
-	TokenIdentifier  string `json:"jti"`
-	NotBeforeUnix    int    `json:"nbf"`
-	Scopes           string `json:"scope"`
-	Subject          string `json:"sub"`
-	TokenType        string `json:"token_type"`
-	UserID           string `json:"uid"`
-	UserName         string `json:"username"`
-	ErrorCode        string `json:"error_code,omitempty"`
-	ErrorDescription string `json:"error_description,omitempty"`
+	responseError
+	Active          bool   `json:"active,omitempty"`
+	Audience        string `json:"aud,omitempty"`
+	ClientID        string `json:"client_id"`
+	DeviceID        string `json:"device_id"`
+	ExpiresUnix     int    `json:"exp"`
+	IssuedAtUnix    int    `json:"iat"`
+	Issuer          string `json:"iss"`
+	TokenIdentifier string `json:"jti"`
+	NotBeforeUnix   int    `json:"nbf"`
+	Scopes          string `json:"scope"`
+	Subject         string `json:"sub"`
+	TokenType       string `json:"token_type"`
+	UserID          string `json:"uid"`
+	UserName        string `json:"username"`
 }
 
-// getTokenInfo information about the given token.
+// getTokenInfo returns information about the given token.
 func (m *userManager) getTokenInfo(ctx context.Context, token, tokenType string) (*introspectResponse, error) {
 	q := url.Values{}
 	q.Add("token", token)
@@ -829,21 +816,26 @@ func (m *userManager) getTokenInfo(ctx context.Context, token, tokenType string)
 	if err != nil {
 		return nil, errors.Wrap(err, "request to introspect token returned error")
 	}
+	tokenInfo := &introspectResponse{}
+	return tokenInfo, readResp(resp, tokenInfo)
+}
+
+// readResp verifies that an Okta response is OK and reads an Okta response body
+// in JSON format to the given output out.
+func readResp(resp *http.Response, out error) error {
+	catcher := grip.NewBasicCatcher()
 	if resp.StatusCode != http.StatusOK {
-		catcher := grip.NewBasicCatcher()
-		catcher.Errorf("received unexpected status code %d", resp.StatusCode)
-		catcher.Wrap(resp.Body.Close(), "error closing response body")
-		return nil, catcher.Resolve()
+		catcher.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+	if err := gimlet.GetJSONUnlimited(resp.Body, out); err != nil {
+		catcher.Wrap(err, "reading JSON response body")
+		return catcher.Resolve()
 	}
 
-	tokenInfo := &introspectResponse{}
-	if err := gimlet.GetJSONUnlimited(resp.Body, tokenInfo); err != nil {
-		return nil, errors.WithStack(err)
+	if errMsg := out.Error(); len(errMsg) != 0 {
+		catcher.New(errMsg)
 	}
-	if tokenInfo.ErrorCode != "" {
-		return tokenInfo, errors.Errorf("%s: %s", tokenInfo.ErrorCode, tokenInfo.ErrorDescription)
-	}
-	return tokenInfo, nil
+	return catcher.Resolve()
 }
 
 // makeUserFromInfo returns a user based on information from a userinfo request.

--- a/okta/okta_test.go
+++ b/okta/okta_test.go
@@ -232,12 +232,12 @@ func (s *mockAuthorizationServer) root(rw http.ResponseWriter, r *http.Request) 
 func (s *mockAuthorizationServer) authorize(rw http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		gimlet.WriteJSONError(rw, &tokenResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &tokenResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.AuthorizeParameters, err = url.ParseQuery(string(body))
 	if err != nil {
-		gimlet.WriteJSONError(rw, &tokenResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &tokenResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.AuthorizeHeaders = r.Header
@@ -250,12 +250,12 @@ func (s *mockAuthorizationServer) authorize(rw http.ResponseWriter, r *http.Requ
 func (s *mockAuthorizationServer) token(rw http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		gimlet.WriteJSONError(rw, &tokenResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &tokenResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.TokenParameters, err = url.ParseQuery(string(body))
 	if err != nil {
-		gimlet.WriteJSONError(rw, &tokenResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &tokenResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.TokenHeaders = r.Header
@@ -278,12 +278,12 @@ func (s *mockAuthorizationServer) userinfo(rw http.ResponseWriter, r *http.Reque
 func (s *mockAuthorizationServer) introspect(rw http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		gimlet.WriteJSONError(rw, &introspectResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &introspectResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.IntrospectParameters, err = url.ParseQuery(string(body))
 	if err != nil {
-		gimlet.WriteJSONError(rw, &introspectResponse{ErrorCode: "invalid_request"})
+		gimlet.WriteJSONError(rw, &introspectResponse{responseError: responseError{ErrorCode: "invalid_request"}})
 		return
 	}
 	s.IntrospectHeaders = r.Header
@@ -321,25 +321,27 @@ func TestRequestHelpers(t *testing.T) {
 			userInfo, err := um.getUserInfo(ctx, "access_token")
 			require.NoError(t, err)
 			mapContains(t, s.UserInfoHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Authorization": []string{"Bearer access_token"},
+				"Accept":        {"application/json"},
+				"Authorization": {"Bearer access_token"},
 			})
 			require.NotNil(t, userInfo)
 			assert.Equal(t, *s.UserInfoResponse, *userInfo)
 		},
 		"GetUserInfoError": func(ctx context.Context, t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			s.UserInfoResponse = &userInfoResponse{
-				Name:             "name",
-				Email:            "email",
-				Groups:           []string{"group"},
-				ErrorCode:        "error_code",
-				ErrorDescription: "error_description",
+				Name:   "name",
+				Email:  "email",
+				Groups: []string{"group"},
+				responseError: responseError{
+					ErrorCode:        "error_code",
+					ErrorDescription: "error_description",
+				},
 			}
 			userInfo, err := um.getUserInfo(ctx, "access_token")
 			assert.Error(t, err)
 			mapContains(t, s.UserInfoHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Authorization": []string{"Bearer access_token"},
+				"Accept":        {"application/json"},
+				"Authorization": {"Bearer access_token"},
 			})
 			require.NotNil(t, userInfo)
 			assert.Equal(t, *s.UserInfoResponse, *userInfo)
@@ -357,41 +359,43 @@ func TestRequestHelpers(t *testing.T) {
 			tokens, err := um.exchangeCodeForTokens(ctx, code)
 			require.NoError(t, err)
 			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Content-Type":  []string{"application/x-www-form-urlencoded"},
-				"Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", um.clientID, um.clientSecret)))},
+				"Accept":        {"application/json"},
+				"Content-Type":  {"application/x-www-form-urlencoded"},
+				"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", um.clientID, um.clientSecret)))},
 			})
 			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":   []string{"authorization_code"},
-				"code":         []string{code},
-				"redirect_uri": []string{um.redirectURI},
+				"grant_type":   {"authorization_code"},
+				"code":         {code},
+				"redirect_uri": {um.redirectURI},
 			})
 			require.NotNil(t, tokens)
 			assert.Equal(t, *s.TokenResponse, *tokens)
 		},
 		"ExchangeCodeForTokensError": func(ctx context.Context, t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			s.TokenResponse = &tokenResponse{
-				AccessToken:      "access_token",
-				IDToken:          "id_token",
-				RefreshToken:     "refresh_token",
-				TokenType:        "token_type",
-				ExpiresIn:        3600,
-				Scope:            "scope",
-				ErrorCode:        "error_code",
-				ErrorDescription: "error_description",
+				AccessToken:  "access_token",
+				IDToken:      "id_token",
+				RefreshToken: "refresh_token",
+				TokenType:    "token_type",
+				ExpiresIn:    3600,
+				Scope:        "scope",
+				responseError: responseError{
+					ErrorCode:        "error_code",
+					ErrorDescription: "error_description",
+				},
 			}
 			code := "some_code"
 			tokens, err := um.exchangeCodeForTokens(ctx, code)
 			assert.Error(t, err)
 			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Content-Type":  []string{"application/x-www-form-urlencoded"},
-				"Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", um.clientID, um.clientSecret)))},
+				"Accept":        {"application/json"},
+				"Content-Type":  {"application/x-www-form-urlencoded"},
+				"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", um.clientID, um.clientSecret)))},
 			})
 			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":   []string{"authorization_code"},
-				"code":         []string{code},
-				"redirect_uri": []string{um.redirectURI},
+				"grant_type":   {"authorization_code"},
+				"code":         {code},
+				"redirect_uri": {um.redirectURI},
 			})
 			require.NotNil(t, tokens)
 			assert.Equal(t, *s.TokenResponse, *tokens)
@@ -744,12 +748,6 @@ func TestClearUser(t *testing.T) {
 				assert.Error(t, err)
 			}
 		})
-	}
-}
-
-func mapContainsKeys(t *testing.T, set map[string]string, subset []string) {
-	for _, name := range subset {
-		assert.Contains(t, set, name)
 	}
 }
 
@@ -1122,22 +1120,25 @@ func TestReauthorization(t *testing.T) {
 			_, err = um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
-			s.IntrospectResponse = &introspectResponse{Active: true}
+			s.IntrospectResponse = &introspectResponse{
+				Active:      true,
+				ExpiresUnix: int(time.Now().Add(time.Hour).Unix()),
+			}
 			s.UserInfoResponse = &userInfoResponse{Name: "foo", Email: "foo@bar.com", Groups: []string{um.userGroup}}
 
 			require.NoError(t, um.ReauthorizeUser(user))
 
 			mapContains(t, s.IntrospectParameters, map[string][]string{
-				"token":           []string{accessToken},
-				"token_type_hint": []string{"access_token"},
+				"token":           {accessToken},
+				"token_type_hint": {"access_token"},
 			})
 			mapContains(t, s.IntrospectHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
 			mapContains(t, s.UserInfoHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Authorization": []string{"Bearer " + accessToken},
+				"Accept":        {"application/json"},
+				"Authorization": {"Bearer " + accessToken},
 			})
 			assert.Empty(t, s.TokenParameters, "reauthorization should succeed without requesting new tokens")
 			assert.Empty(t, s.TokenHeaders, "reauthorization should succeed without requesting new tokens")
@@ -1167,7 +1168,10 @@ func TestReauthorization(t *testing.T) {
 				}, nil
 			}
 
-			s.IntrospectResponse = &introspectResponse{Active: true}
+			s.IntrospectResponse = &introspectResponse{
+				Active:      true,
+				ExpiresUnix: int(time.Now().Add(time.Hour).Unix()),
+			}
 			s.UserInfoResponse = &userInfoResponse{Name: "foo", Email: "foo@bar.com", Groups: []string{um.userGroup}}
 			s.TokenResponse = &tokenResponse{
 				AccessToken:  newAccessToken,
@@ -1181,16 +1185,22 @@ func TestReauthorization(t *testing.T) {
 			require.NoError(t, um.ReauthorizeUser(user))
 
 			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":    []string{"refresh_token"},
-				"refresh_token": []string{refreshToken},
-				"scope":         []string{"openid email profile offline_access groups"},
+				"grant_type":    {"refresh_token"},
+				"refresh_token": {refreshToken},
+				"scope":         {"openid email profile offline_access groups"},
 			})
 			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
-			assert.Empty(t, s.IntrospectParameters, "should not check access token if not validating groups")
-			assert.Empty(t, s.IntrospectHeaders, "should not check access token if not validating groups")
+			mapContains(t, s.IntrospectParameters, map[string][]string{
+				"token":           {refreshToken},
+				"token_type_hint": {"refresh_token"},
+			})
+			mapContains(t, s.IntrospectHeaders, map[string][]string{
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
+			})
 			assert.Empty(t, s.UserInfoHeaders, "should not get user info if not validating groups")
 
 			cachedUser, _, err := um.cache.Find(user.Username())
@@ -1223,7 +1233,7 @@ func TestReauthorization(t *testing.T) {
 			assert.Empty(t, s.IntrospectParameters, "should not check access token if not validating groups")
 			assert.Empty(t, s.UserInfoHeaders, "should not get user info if not validating groups")
 		},
-		"FailsIfAccessTokenExpiredAndTokensCannotRefresh": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
+		"FailsIfAccessTokenAndRefreshTokenExpired": func(t *testing.T, um *userManager, s *mockAuthorizationServer) {
 			um.validateGroups = true
 
 			accessToken := "access_token"
@@ -1235,31 +1245,29 @@ func TestReauthorization(t *testing.T) {
 			_, err = um.cache.GetOrCreate(user)
 			require.NoError(t, err)
 
-			s.IntrospectResponse = &introspectResponse{Active: false}
+			s.IntrospectResponse = &introspectResponse{
+				Active:      false,
+				ExpiresUnix: int(time.Now().Add(-time.Hour).Unix()),
+			}
 			s.TokenResponse = &tokenResponse{
-				ErrorCode:        "error",
-				ErrorDescription: "error_description",
+				responseError: responseError{
+					ErrorCode:        "error",
+					ErrorDescription: "error_description",
+				},
 			}
 
-			assert.Error(t, um.ReauthorizeUser(user))
+			err = um.ReauthorizeUser(user)
+			assert.Equal(t, gimlet.ErrNeedsReauthentication, errors.Cause(err))
 
 			mapContains(t, s.IntrospectParameters, map[string][]string{
-				"token":           []string{accessToken},
-				"token_type_hint": []string{"access_token"},
+				"token":           {refreshToken},
+				"token_type_hint": {"refresh_token"},
 			})
 			mapContains(t, s.IntrospectHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
-			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":    []string{"refresh_token"},
-				"refresh_token": []string{refreshToken},
-				"scope":         []string{"openid email profile offline_access groups"},
-			})
-			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
-			})
+			assert.Empty(t, s.TokenHeaders)
 			assert.Empty(t, s.UserInfoHeaders)
 
 			cachedUser, _, err := um.cache.Find(user.Username())
@@ -1272,7 +1280,10 @@ func TestReauthorization(t *testing.T) {
 			accessToken := "access_token"
 			refreshToken := "refresh_token"
 			newAccessToken := "new_access_token"
-			s.IntrospectResponse = &introspectResponse{Active: true}
+			s.IntrospectResponse = &introspectResponse{
+				Active:      true,
+				ExpiresUnix: int(time.Now().Add(time.Hour).Unix()),
+			}
 			s.TokenResponse = &tokenResponse{
 				AccessToken:  newAccessToken,
 				IDToken:      "new_id_token",
@@ -1291,25 +1302,25 @@ func TestReauthorization(t *testing.T) {
 			assert.Error(t, um.ReauthorizeUser(user))
 
 			mapContains(t, s.IntrospectParameters, map[string][]string{
-				"token":           []string{newAccessToken},
-				"token_type_hint": []string{"access_token"},
+				"token":           {newAccessToken},
+				"token_type_hint": {"access_token"},
 			})
 			mapContains(t, s.IntrospectHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
 			mapContains(t, s.TokenParameters, map[string][]string{
-				"grant_type":    []string{"refresh_token"},
-				"refresh_token": []string{refreshToken},
-				"scope":         []string{"openid email profile offline_access groups"},
+				"grant_type":    {"refresh_token"},
+				"refresh_token": {refreshToken},
+				"scope":         {"openid email profile offline_access groups"},
 			})
 			mapContains(t, s.TokenHeaders, map[string][]string{
-				"Content-Type": []string{"application/x-www-form-urlencoded"},
-				"Accept":       []string{"application/json"},
+				"Content-Type": {"application/x-www-form-urlencoded"},
+				"Accept":       {"application/json"},
 			})
 			mapContains(t, s.UserInfoHeaders, map[string][]string{
-				"Accept":        []string{"application/json"},
-				"Authorization": []string{"Bearer " + newAccessToken},
+				"Accept":        {"application/json"},
+				"Authorization": {"Bearer " + newAccessToken},
 			})
 
 			cachedUser, _, err := um.cache.Find(user.Username())

--- a/okta/okta_test.go
+++ b/okta/okta_test.go
@@ -1193,8 +1193,8 @@ func TestReauthorization(t *testing.T) {
 				"Content-Type": {"application/x-www-form-urlencoded"},
 				"Accept":       {"application/json"},
 			})
-			assert.Empty(t, s.IntrospectParameters, "should not introspect token if not validating groups")
-			assert.Empty(t, s.IntrospectHeaders, "should not introspect token if not validating groups")
+			assert.Empty(t, s.IntrospectParameters, "should not introspect access token if not validating groups")
+			assert.Empty(t, s.IntrospectHeaders, "should not introspect access token if not validating groups")
 			assert.Empty(t, s.UserInfoHeaders, "should not get user info if not validating groups")
 
 			cachedUser, _, err := um.cache.Find(user.Username())


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12629

If the response body we receive from Okta includes an error message, return that error message. Before, we wouldn't consider the response body if it returned non-200, but the body often contains the error message encoded in JSON. The body error message lets us know if the refresh token is expired, in which case the only way to get a new one is to log into Okta again (i.e. log into the UI).