### PR TITLE
EVG-14486: use archlinux-new distros in CI tests

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -138,7 +138,7 @@ buildvariants:
       TEST_TIMEOUT: 15m
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
     run_on:
-      - ubuntu1604-test
+      - archlinux-new-small
     tasks:
       - name: ".test"
 

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -136,7 +136,7 @@ buildvariants:
       GOROOT: /opt/golang/go1.13
       RACE_DETECTOR: true
       TEST_TIMEOUT: 15m
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.13.tgz
     run_on:
       - archlinux-new-small
     tasks:


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14486