### PR TITLE
EVG-14482, EVG-14502: upgrade go version and linter

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -30,8 +30,8 @@ functions:
     params:
       working_dir: gopath/src/github.com/evergreen-ci/gimlet
       binary: make
-      args: ["${make_args|}", "${target}"]
-      add_expansions_to_env: true
+      args: ["${target}"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR", "TEST_TIMEOUT"]
       env:
         GOPATH: ${workdir}/gopath
   setup-mongodb:
@@ -118,7 +118,6 @@ tasks:
       - func: run-make
         vars:
           target: "coverage-html"
-          make_args: "-k"
 
   - <<: *run-build
     tags: ["test"]
@@ -132,8 +131,8 @@ buildvariants:
     display_name: Race Detector (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
       TEST_TIMEOUT: 15m
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.13.tgz
@@ -145,25 +144,25 @@ buildvariants:
   - name: coverage
     display_name: Coverage
     run_on:
-      - ubuntu1604-test
+      - ubuntu1804-small
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       TEST_TIMEOUT: 15m
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.3.tgz
     tasks:
       - name: ".report"
         stepback: false
 
-  - name: ubuntu1604
-    display_name: Ubuntu 16.04
+  - name: ubuntu
+    display_name: Ubuntu 18.04
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.9/bin/go
-      GOROOT: /opt/golang/go1.9
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       DISABLE_COVERAGE: true
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.3.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.3.tgz
     run_on:
-      - ubuntu1604-test
+      - ubuntu1804-small
     tasks:
       - ".test"
 
@@ -171,8 +170,8 @@ buildvariants:
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     run_on:
       - macos-1014

--- a/makefile
+++ b/makefile
@@ -23,6 +23,7 @@ endif
 export GOPATH := $(gopath)
 export GOCACHE := $(gocache)
 export GOROOT := $(goroot)
+export GO111MODULE := off
 # end environment setup
 
 
@@ -33,7 +34,7 @@ $(shell mkdir -p $(buildDir))
 # start lint setup targets
 lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-14482
https://jira.mongodb.org/browse/EVG-14502

* Upgrade go to 1.16.
* Upgrade golangci-lint to 1.40.
* Upgrade Ubuntu to 18.04.