### PR TITLE
EVG-14757: Use encoded URL paths

### DIFF
--- a/app_resolve.go
+++ b/app_resolve.go
@@ -25,7 +25,7 @@ func (a *APIApp) Resolve() error {
 	}
 
 	if a.router == nil {
-		a.router = mux.NewRouter().StrictSlash(a.StrictSlash)
+		a.router = mux.NewRouter().StrictSlash(a.StrictSlash).UseEncodedPath()
 	}
 
 	if err := a.attachRoutes(a.router, true); err != nil {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14757

I can't think of a reason this should not be turned on by default.