### PR TITLE
EVG-14886: use Okta default authorization server

### DIFF
--- a/okta/okta.go
+++ b/okta/okta.go
@@ -25,6 +25,9 @@ type CreationOptions struct {
 	ClientSecret string
 	RedirectURI  string
 	Issuer       string
+	// Scopes define the user information to request when authorizing the user.
+	// See https://developer.okta.com/docs/reference/api/oidc/#access-token-scopes-and-claims
+	Scopes []string
 
 	UserGroup string
 	// If set, user can be reauthorized without needing to authenticate.
@@ -32,7 +35,9 @@ type CreationOptions struct {
 	// If set, authentication and reauthorization will validate the group for
 	// the user matches UserGroup. Otherwise, it simply checks that the user
 	// attempting to reauthorize has the same name as that returned by the ID
-	// token.
+	// token. This validation is only possible when the issuer returns group
+	// information from its endpoints, which requires the application to have
+	// permission to request them as part of the scopes.
 	ValidateGroups bool
 
 	CookiePath   string
@@ -59,6 +64,7 @@ func (opts *CreationOptions) Validate() error {
 	catcher.NewWhen(opts.ClientSecret == "", "must specify client secret")
 	catcher.NewWhen(opts.RedirectURI == "", "must specify redirect URI")
 	catcher.NewWhen(opts.Issuer == "", "must specify issuer")
+	catcher.NewWhen(len(opts.Scopes) == 0, "must specify at least one scope")
 	if opts.ValidateGroups {
 		catcher.NewWhen(opts.UserGroup == "", "must specify user group")
 	}
@@ -85,6 +91,7 @@ type userManager struct {
 	clientSecret string
 	redirectURI  string
 	issuer       string
+	scopes       []string
 
 	userGroup string
 
@@ -134,6 +141,7 @@ func NewUserManager(opts CreationOptions) (gimlet.UserManager, error) {
 		redirectURI:          opts.RedirectURI,
 		issuer:               opts.Issuer,
 		userGroup:            opts.UserGroup,
+		scopes:               opts.Scopes,
 		cookiePath:           opts.CookiePath,
 		cookieDomain:         opts.CookieDomain,
 		cookieTTL:            opts.CookieTTL,
@@ -357,7 +365,7 @@ func (m *userManager) GetLoginHandler(_ string) http.HandlerFunc {
 		q.Add("client_id", m.clientID)
 		q.Add("response_type", "code")
 		q.Add("response_mode", "query")
-		q.Add("scope", m.scopes())
+		q.Add("scope", m.requestScopes())
 		if !canSilentReauth {
 			q.Add("prompt", "login consent")
 		}
@@ -366,7 +374,7 @@ func (m *userManager) GetLoginHandler(_ string) http.HandlerFunc {
 		q.Add("nonce", nonce)
 
 		r.Header.Add("Cache-Control", "no-cache,no-store")
-		http.Redirect(w, r, fmt.Sprintf("%s/oauth2/v1/authorize?%s", m.issuer, q.Encode()), http.StatusFound)
+		http.Redirect(w, r, fmt.Sprintf("%s/v1/authorize?%s", m.issuer, q.Encode()), http.StatusFound)
 	}
 }
 
@@ -514,8 +522,7 @@ func (m *userManager) getUserTokens(code, nonce string) (*tokenResponse, *jwtver
 func (m *userManager) generateUserFromInfo(accessToken, refreshToken string) (gimlet.User, error) {
 	userInfo, err := m.getUserInfo(context.Background(), accessToken)
 	if err != nil {
-		err = errors.Wrap(err, "could not retrieve user info from Okta")
-		return nil, err
+		return nil, errors.Wrap(err, "could not retrieve user info from Okta")
 	}
 	if m.validateGroups {
 		if err := m.validateGroup(userInfo.Groups); err != nil {
@@ -675,19 +682,19 @@ func (m *userManager) refreshTokens(ctx context.Context, refreshToken string) (*
 	q := url.Values{}
 	q.Set("grant_type", "refresh_token")
 	q.Set("refresh_token", refreshToken)
-	q.Set("scope", m.scopes())
+	q.Set("scope", m.requestScopes())
 	return m.redeemTokens(ctx, q.Encode())
 }
 
-// scopes returns the necessary scopes for Okta to return.
-func (m *userManager) scopes() string {
-	return "openid email profile offline_access groups"
+// requestScopes returns the necessary scopes that Okta must return.
+func (m *userManager) requestScopes() string {
+	return strings.Join(m.scopes, " ")
 }
 
 // redeemTokens sends the request to redeem tokens with the required client
 // credentials.
 func (m *userManager) redeemTokens(ctx context.Context, query string) (*tokenResponse, error) {
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/oauth2/v1/token", m.issuer), bytes.NewBufferString(query))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/v1/token", m.issuer), bytes.NewBufferString(query))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -727,7 +734,7 @@ type userInfoResponse struct {
 // getUserInfo uses the access token to retrieve user information from the
 // userinfo endpoint.
 func (m *userManager) getUserInfo(ctx context.Context, accessToken string) (*userInfoResponse, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/oauth2/v1/userinfo", m.issuer), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/userinfo", m.issuer), nil)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -777,7 +784,7 @@ func (m *userManager) getTokenInfo(ctx context.Context, token, tokenType string)
 	q := url.Values{}
 	q.Add("token", token)
 	q.Add("token_type_hint", tokenType)
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/oauth2/v1/introspect", m.issuer), strings.NewReader(q.Encode()))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/v1/introspect", m.issuer), strings.NewReader(q.Encode()))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -64,7 +64,6 @@ func (opts *CreationOptions) Validate() error {
 	catcher.NewWhen(opts.ClientSecret == "", "must specify client secret")
 	catcher.NewWhen(opts.RedirectURI == "", "must specify redirect URI")
 	catcher.NewWhen(opts.Issuer == "", "must specify issuer")
-	catcher.NewWhen(len(opts.Scopes) == 0, "must specify at least one scope")
 	if opts.ValidateGroups {
 		catcher.NewWhen(opts.UserGroup == "", "must specify user group")
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14886

In our Okta authentication, we've been using `/oauth2/v1` routes to make requests to Okta. The route that we use to authorize users (i.e. the one that shows the Okta login page to the user) returns special tokens that allow users to use the REST API without an associated session in the website. However, these routes return tokens that expire after 100 days, which is frustrating to users, because you get 401 unauthorized responses from the API and you have to re-login to the Evergreen UI.

Switching from using `/oauth2/v1` to `/oauth2/default/v1` will give us tokens that never expire, so you can use the Evergreen CLI without the 100-day expiration. **As a consequence of this, we're going to have to log everyone out of Evergreen because the tokens returned from `/oauth2/v1` (i.e. the current tokens that everyone has) are not valid for the `/oauth2/default/v1 routes`.** We could try to make it temporarily backwards compatible until 100 days have passed by making requests to both routes whenever we authorize/reauthorize a user, but I would prefer not to do that if we don't have to since we'll be spamming the Okta server with bad requests and it slows down login/reauthorization.

* Change Okta oauth routes from `/oauth2/v1` to `/oauth2/default/v1` to get unexpirable tokens.
* Make scopes configurable. Scopes are user information that you can request from Okta to get useful user information when they log in (e.g. email, display name). I made the scopes configurable because they used to be hard-coded. However, the `/oauth2/v1` request used to ask for the "groups" scope, which `/oauth2/default/v1` does not give us permission to retrieve. We're still going to request all the other scopes (openid, email, profile, offline_access).