### PR TITLE
EVG-14923: Decode strings for all arguments passed to URL

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -23,7 +23,7 @@ func GetVars(r *http.Request) map[string]string {
 	for k, v := range vars {
 		unescapedVar, err := url.PathUnescape(v)
 		if err != nil {
-			return nil
+			return make(map[string]string)
 		}
 		vars[k] = unescapedVar
 	}

--- a/parsing.go
+++ b/parsing.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -18,7 +19,15 @@ const maxRequestSize = 16 * 1024 * 1024 // 16 MB
 // passed to the method in the URL. Use this helper function when
 // writing handler functions.
 func GetVars(r *http.Request) map[string]string {
-	return mux.Vars(r)
+	vars := mux.Vars(r)
+	for k, v := range vars {
+		unescapedVar, err := url.PathUnescape(v)
+		if err != nil {
+			return nil
+		}
+		vars[k] = unescapedVar
+	}
+	return vars
 }
 
 // SetURLVars sets URL variables for testing purposes only.

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type jsonishParser func(io.ReadCloser, interface{}) error
@@ -81,8 +82,8 @@ func TestSetURLVars(t *testing.T) {
 }
 
 func TestDecodeVars(t *testing.T) {
-	r, err := http.NewRequest("GET", "/url", nil)
-	assert.NoError(t, err)
+	r, err := http.NewRequest(http.MethodGet, "/url", nil)
+	require.NoError(t, err)
 	vars := map[string]string{"task_id": "should%21decode", "project_id": "shouldnt_decode", "patch_id": "shouldnt/decode"}
 	r = SetURLVars(r, vars)
 	assert.Equal(t, "should!decode", GetVars(r)["task_id"])

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -79,3 +79,13 @@ func TestSetURLVars(t *testing.T) {
 	r = SetURLVars(r, vars)
 	assert.Equal(t, vars, GetVars(r))
 }
+
+func TestDecodeVars(t *testing.T) {
+	r, err := http.NewRequest("GET", "/url", nil)
+	assert.NoError(t, err)
+	vars := map[string]string{"task_id": "should%21decode", "project_id": "shouldnt_decode", "patch_id": "shouldnt/decode"}
+	r = SetURLVars(r, vars)
+	assert.Equal(t, "should!decode", GetVars(r)["task_id"])
+	assert.Equal(t, "shouldnt_decode", GetVars(r)["project_id"])
+	assert.Equal(t, "shouldnt/decode", GetVars(r)["patch_id"])
+}


### PR DESCRIPTION
[EVG-14923](https://jira.mongodb.org/browse/EVG-14923)
A change was recently made in gimlet  to allow encoded paths in the url when setting up the initial mux router: evergreen-ci/gimlet@5fbd893. This caused methods in the middleware to break because gimlet.getVars(r) would now retrieve encoded task Ids, resulting in 404 errors. There is a comment above getVars in the codebase saying that it returns decoded parameters but that is no longer the case due to the linked change. Change has been added to decode parameters when calling getVars.