### PR TITLE
EVG-15423: remove double slashes in URL to prevent open redirect issues

### DIFF
--- a/vendor/github.com/urfave/negroni/static.go
+++ b/vendor/github.com/urfave/negroni/static.go
@@ -65,6 +65,7 @@ func (s *Static) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	if fi.IsDir() {
 		// redirect if missing trailing slash
 		if !strings.HasSuffix(r.URL.Path, "/") {
+			//avoid open redirect issue if path starts with double slash EVG-15423
 			if strings.HasPrefix(r.URL.Path, "//") {
 				r.URL.Path = "/" + strings.TrimLeft(r.URL.Path, "/")
 			}

--- a/vendor/github.com/urfave/negroni/static.go
+++ b/vendor/github.com/urfave/negroni/static.go
@@ -66,6 +66,9 @@ func (s *Static) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 		// redirect if missing trailing slash
 		if !strings.HasSuffix(r.URL.Path, "/") {
 			r.URL.Path += "/"
+			if strings.HasPrefix(r.URL.Path, "//") {
+				r.URL.Path = dedupeURLSlashes(r.URL.Path)
+			}
 			http.Redirect(rw, r, r.URL.String(), http.StatusFound)
 			return
 		}
@@ -86,4 +89,17 @@ func (s *Static) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	}
 
 	http.ServeContent(rw, r, file, fi.ModTime(), f)
+}
+
+func dedupeURLSlashes(path string) string {
+	goodURL := ""
+	lastChar := rune(0)
+	for _, char := range path {
+		if lastChar == char && lastChar == '/' {
+			continue
+		}
+		goodURL += string(char)
+		lastChar = char
+	}
+	return goodURL
 }


### PR DESCRIPTION
Double slash seems to have been causing an open redirect issue, see ticket for details. We now make sure that the path does not have any leading //, which would cause certain URLs with special characters to redirect to an external site.