### PR TITLE
EVG-15384 Add accessor methods to gimlet routes

### DIFF
--- a/app_routing.go
+++ b/app_routing.go
@@ -88,6 +88,10 @@ func (a *APIApp) PrefixRoute(p string) *APIRoute {
 	return route
 }
 
+func (a *APIApp) Routes() []*APIRoute {
+	return a.routes
+}
+
 // Route allows you to set or reset the route path on an existing route.
 func (r *APIRoute) Route(route string) *APIRoute {
 	r.route = route
@@ -275,4 +279,18 @@ func (r *APIRoute) Method(m string) *APIRoute {
 	default:
 		return r
 	}
+}
+
+func (r *APIRoute) HasMethod(method string) bool {
+	for _, m := range r.methods {
+		if m.String() == method {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *APIRoute) GetRoute() string {
+	return r.route
 }

--- a/app_routing_test.go
+++ b/app_routing_test.go
@@ -249,3 +249,14 @@ func (s *RoutingSuite) TestRouteWrapperMutators() {
 	r.ClearWrappers()
 	s.Len(r.wrappers, 0)
 }
+
+func (s *RoutingSuite) TestRouteInfo() {
+	r := s.app.AddRoute("/foo")
+	s.Len(s.app.Routes(), 1)
+	s.Equal(r.GetRoute(), "/foo")
+	bar := s.app.AddRoute("/bar").Post()
+	s.Len(s.app.Routes(), 2)
+	s.Equal(bar.GetRoute(), "/bar")
+	s.True(bar.HasMethod("POST"))
+	s.False(bar.HasMethod("GET"))
+}


### PR DESCRIPTION
Adding these methods to allow us to programmatically access gimlet route values. 

This is a requirement for https://github.com/evergreen-ci/evergreen/pull/5053