### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -31,7 +31,7 @@ functions:
       working_dir: gopath/src/github.com/evergreen-ci/gimlet
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR", "TEST_TIMEOUT"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR", "TEST_TIMEOUT"]
       env:
         GOPATH: ${workdir}/gopath
   setup-mongodb:
@@ -131,7 +131,6 @@ buildvariants:
     display_name: Race Detector (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
       TEST_TIMEOUT: 15m
@@ -146,7 +145,6 @@ buildvariants:
     run_on:
       - ubuntu1804-small
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       TEST_TIMEOUT: 15m
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.3.tgz
@@ -157,7 +155,6 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 18.04
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       DISABLE_COVERAGE: true
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.3.tgz
@@ -170,7 +167,6 @@ buildvariants:
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     run_on:

--- a/makefile
+++ b/makefile
@@ -2,111 +2,86 @@
 name := gimlet
 buildDir := build
 packages := $(name) acl ldap okta rolemanager
+compilePackages := $(subst $(name),,$(subst -,/,$(foreach target,$(packages),./$(target))))
 orgPath := github.com/evergreen-ci
 projectPath := $(orgPath)/$(name)
 # end project configuration
 
 # start environment setup
-gobin := $(GO_BIN_PATH)
-ifeq ($(gobin),)
 gobin := go
-endif
-gopath := $(GOPATH)
-gocache := $(abspath $(buildDir)/.cache)
-goroot := $(GOROOT)
-ifeq ($(OS),Windows_NT)
-gocache := $(shell cygpath -m $(gocache))
-gopath := $(shell cygpath -m $(gopath))
-goroot := $(shell cygpath -m $(goroot))
+ifneq (,$(GOROOT))
+gobin := $(GOROOT)/bin/go
 endif
 
-export GOPATH := $(gopath)
-export GOCACHE := $(gocache)
-export GOROOT := $(goroot)
+ifeq ($(OS),Windows_NT)
+gobin := $(shell cygpath $(gobin))
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(GOROOT))
+endif
+
 export GO111MODULE := off
 # end environment setup
 
-
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
-
 
 # start lint setup targets
 lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
+$(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets
 
-
-######################################################################
-##
-## Everything below this point is generic, and does not contain
-## project specific configuration. (with one noted case in the "build"
-## target for library-only projects)
-##
-######################################################################
-
-
-# start dependency installation tools
-#   implementation details for being able to lazily install dependencies
+# start output files
 testOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).test))
 lintOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).lint))
 coverageOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).coverage))
 coverageHtmlOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html))
-# end dependency installation tools
-
-
-# lint setup targets
-# end lint setup targets
-
-# userfacing targets for basic build and development operations
-lint:$(lintOutput)
-compile $(buildDir):
-	$(gobin) build ./.
-test:$(testOutput)
-coverage:$(coverageOutput)
-coverage-html:$(coverageHtmlOutput)
-phony := build test coverage coverage-html
 .PRECIOUS: $(testOutput) $(lintOuptut) $(coverageOutput) $(coverageHtmlOutput)
-# end front-ends
+# end output files
 
-# convenience targets for runing tests and coverage tasks on a
+# start basic development operations
+lint: $(lintOutput)
+compile:
+	$(gobin) build $(compilePackages)
+test: $(testOutput)
+coverage: $(coverageOutput)
+coverage-html: $(coverageHtmlOutput)
+phony := compile test coverage coverage-html
+
+# start convenience targets for running tests and coverage tasks on a
 # specific package.
-test-%:$(buildDir)/output.%.test
+test-%: $(buildDir)/output.%.test
 	@grep -s -q -e "^PASS" $<
-coverage-%:$(buildDir)/output.%.coverage
+coverage-%: $(buildDir)/output.%.coverage
 
-html-coverage-%:$(buildDir)/output.%.coverage.html
+html-coverage-%: $(buildDir)/output.%.coverage.html
 	
-lint-%:$(buildDir)/output.%.lint
+lint-%: $(buildDir)/output.%.lint
 	@grep -v -s -q "^--- FAIL" $<
-# end convienence targets
-
+# end convenience targets
+# end basic development operations
 
 # start test and coverage artifacts
-#    tests have compile and runtime deps. This varable has everything
-#    that the tests actually need to run. (The "build" target is
-#    intentional and makes these targets rerun as expected.)
 testArgs := -v
 ifeq (,$(DISABLE_COVERAGE))
-	testArgs += -cover
+testArgs += -cover
 endif
 ifneq (,$(RACE_DETECTOR))
-	testArgs += -race
+testArgs += -race
 endif
 ifneq (,$(RUN_TEST))
-	testArgs += -run='$(RUN_TEST)'
+testArgs += -run='$(RUN_TEST)'
 endif
 ifneq (,$(RUN_COUNT))
-	testArgs += -count=$(RUN_COUNT)
+testArgs += -count=$(RUN_COUNT)
 endif
 ifneq (,$(TEST_TIMEOUT))
-	testArgs += -timeout=$(TEST_TIMEOUT)
+testArgs += -timeout=$(TEST_TIMEOUT)
 endif
-#    implementation for package coverage and test running,mongodb to produce
-#    and save test output.
 $(buildDir)/output.%.coverage: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
@@ -114,12 +89,15 @@ $(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage .FORCE
 	$(gobin) tool cover -html=$< -o $@
 $(buildDir)/output.%.test: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $(buildDir)/output.$(subst /,-,$*).test
-#  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
-$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
-	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
-# end test and coverage artifacts
 
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
+$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
+# end test and coverage artifacts
 
 # start vendoring configuration
 vendor-clean:
@@ -132,16 +110,7 @@ vendor-clean:
 phony += vendor-clean
 # end vendoring tooling configuration
 
-
-# clean and other utility targets
-clean:
-	rm -rf $(lintDeps)
-clean-results:
-	rm -rf $(buildDir)/output.*
-phony += clean
-# end dependency targets
-
-# mongodb utility targets
+# start mongodb targets
 mongodb/.get-mongodb:
 	rm -rf mongodb
 	mkdir -p mongodb
@@ -152,13 +121,22 @@ get-mongodb: mongodb/.get-mongodb
 start-mongod: mongodb/.get-mongodb
 	./mongodb/mongod --dbpath ./mongodb/db_files --port 27017 --replSet evg --smallfiles --oplogSize 10
 	@echo "waiting for mongod to start up"
-init-rs:mongodb/.get-mongodb
+init-rs: mongodb/.get-mongodb
 	./mongodb/mongo --eval 'rs.initiate()'
 check-mongod: mongodb/.get-mongodb
 	./mongodb/mongo --nodb --eval "assert.soon(function(x){try{var d = new Mongo(\"localhost:27017\"); return true}catch(e){return false}}, \"timed out connecting\")"
 	@echo "mongod is up"
+phony += get-mongodb start-mongod init-rs check-mongod
 # end mongodb targets
+
+# start cleanup targets
+clean:
+	rm -rf $(buildDir)
+clean-results:
+	rm -rf $(buildDir)/output.*
+phony += clean clean-results
+# end cleanup targets
 
 # configure phony targets
 .FORCE:
-.PHONY:$(phony)
+.PHONY: $(phony)


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-15479
https://jira.mongodb.org/browse/EVG-15495

* Remove GO_BIN_PATH. CI tests now depend on GOROOT to tell them which Go version to use and which Go binary to use.
* Set the GOLANGCI_LINT_CACHE, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the PATH variable for the linter.
* Clean up and standardize the makefile.