### PR TITLE
EVG-15682: remove DISABLE_COVERAGE flag

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -41,7 +41,7 @@ functions:
       working_dir: gimlet
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["GOROOT", "RACE_DETECTOR"]
   setup-mongodb:
     - command: subprocess.exec
       type: setup
@@ -165,7 +165,6 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector (Arch Linux)
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.13.tgz
@@ -189,7 +188,6 @@ buildvariants:
     display_name: Ubuntu 18.04
     expansions:
       GOROOT: /opt/golang/go1.16
-      DISABLE_COVERAGE: true
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.3.tgz
     run_on:
       - ubuntu1804-small
@@ -199,7 +197,6 @@ buildvariants:
   - name: macos
     display_name: macOS
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     run_on:

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -140,7 +140,7 @@ tasks:
       - func: setup-mongodb
       - func: run-make
         vars:
-          target: "coverage-html"
+          target: html-coverage
 
   - <<: *run-build
     tags: ["test"]

--- a/makefile
+++ b/makefile
@@ -69,8 +69,8 @@ $(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 testOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).test))
 lintOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).lint))
 coverageOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).coverage))
-coverageHtmlOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html))
-.PRECIOUS: $(testOutput) $(lintOuptut) $(coverageOutput) $(coverageHtmlOutput)
+htmlCoverageOutput := $(subst -,/,$(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html))
+.PRECIOUS: $(testOutput) $(lintOuptut) $(coverageOutput) $(htmlCoverageOutput)
 # end output files
 
 # start basic development operations
@@ -79,8 +79,8 @@ compile:
 	$(gobin) build $(compilePackages)
 test: $(testOutput)
 coverage: $(coverageOutput)
-coverage-html: $(coverageHtmlOutput)
-phony := compile test coverage coverage-html
+html-coverage: $(htmlCoverageOutput)
+phony := compile test lint coverage html-coverage
 
 # start convenience targets for running tests and coverage tasks on a
 # specific package.

--- a/makefile
+++ b/makefile
@@ -97,9 +97,6 @@ lint-%: $(buildDir)/output.%.lint
 
 # start test and coverage artifacts
 testArgs := -v
-ifeq (,$(DISABLE_COVERAGE))
-testArgs += -cover
-endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15682

Remove the `DISABLE_COVERAGE` flag. The only thing that this does is when you run `make test-<package>`, it adds a summary line at the end of the go test output to include the percentage of lines covered that looks like this:
```
coverage:  <N>% of statements
```
I don't think this is particularly useful - instead, it's more useful is to run `make coverage-<package>` or `make html-coverage-<package>`, which produces more detailed information about code coverage rather than a single aggregate coverage number. Those coverage targets do not depend on `DISABLE_COVERAGE`.