### PR TITLE
EVG-14198 log usernames

### DIFF
--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -84,6 +84,7 @@ func (umc UserMiddlewareConfiguration) ClearCookie(rw http.ResponseWriter) {
 }
 
 func setUserForRequest(r *http.Request, u User) *http.Request {
+	AddLoggingAnnotation(r, "user", u.Username())
 	return r.WithContext(AttachUser(r.Context(), u))
 }
 

--- a/middleware_grip.go
+++ b/middleware_grip.go
@@ -51,8 +51,8 @@ func AddLoggingAnnotation(r *http.Request, key string, value interface{}) {
 	annotations[key] = value
 }
 
-func setLoggingAnnotations(r *http.Request) *http.Request {
-	return r.WithContext(context.WithValue(r.Context(), loggingAnnotationsKey, make(loggingAnnotations)))
+func setLoggingAnnotations(r *http.Request, annotations loggingAnnotations) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), loggingAnnotationsKey, annotations))
 }
 
 func getLoggingAnnotations(ctx context.Context) loggingAnnotations {
@@ -116,7 +116,7 @@ func setupLogger(logger grip.Journaler, r *http.Request) *http.Request {
 	r = setRequestID(r, id)
 	startAt := time.Now()
 	r = setStartAtTime(r, startAt)
-	r = setLoggingAnnotations(r)
+	r = setLoggingAnnotations(r, loggingAnnotations{})
 
 	logger.Info(message.Fields{
 		"action":  "started",

--- a/middleware_grip_test.go
+++ b/middleware_grip_test.go
@@ -171,7 +171,7 @@ func TestLoggingAnnotations(t *testing.T) {
 		URL:    &url.URL{},
 		Header: http.Header{},
 	}
-	req = setLoggingAnnotations(req)
+	req = setLoggingAnnotations(req, loggingAnnotations{})
 	AddLoggingAnnotation(req, "key", "value")
 
 	la := getLoggingAnnotations(req.Context())


### PR DESCRIPTION
[EVG-14198](https://jira.mongodb.org/browse/EVG-14198)

If the user is authenticated we'd like to include the username in the log. We attempted this previously (#87) but it wasn't getting included in the log message. 
This confused me for a while. After investigating, I think the reason is that although the user middleware [adds the user to its request's context](https://github.com/evergreen-ci/gimlet/blob/bcf5586bf67539400214d4f562ed27040458aa61/middleware_auth_user.go#L86-L88) the request of the previous caller in the middleware chain is unchanged so [when we go to log it](https://github.com/evergreen-ci/gimlet/blob/bcf5586bf67539400214d4f562ed27040458aa61/middleware_grip.go#L142) the user is still nil. The question, though, is: why is the request unchanged in the caller? Doesn't it [pass a request pointer to the rest of the chain](https://github.com/evergreen-ci/gimlet/blob/bcf5586bf67539400214d4f562ed27040458aa61/middleware_grip.go#L210)?
I think the answer is that [this line](https://github.com/evergreen-ci/gimlet/blob/bcf5586bf67539400214d4f562ed27040458aa61/middleware_auth_user.go#L164) doesn't change the request itself, just the _pointer_ to the request. In other words, `r` holds an address that points to the request struct. What the line does is change to address that r is holding to point at a different request. So when we get back to the caller **its** `r` is still pointing to the original, unchanged, request.
Another way to say this is that the following _would_ work
```
*r = *setUserForRequest(r, usr)
``` 
I think that while this would work it's not my preference. I prefer that instead of relying on uncontrolled changes to the request we extend the existing framework for adding key-value pairs to the message and use it for adding the username to the message.