### PR TITLE
EVG-15787 add params to logs

### DIFF
--- a/middleware_grip.go
+++ b/middleware_grip.go
@@ -117,6 +117,7 @@ func setupLogger(logger grip.Journaler, r *http.Request) *http.Request {
 		"remote":  r.RemoteAddr,
 		"request": id,
 		"path":    r.URL.Path,
+		"params":  r.URL.Query(),
 	})
 
 	return r
@@ -132,6 +133,7 @@ func finishLogger(logger grip.Journaler, r *http.Request, res negroni.ResponseWr
 		"remote":      r.RemoteAddr,
 		"request":     GetRequestID(ctx),
 		"path":        r.URL.Path,
+		"params":      r.URL.Query(),
 		"duration_ms": int64(dur / time.Millisecond),
 		"action":      "completed",
 		"status":      res.Status(),


### PR DESCRIPTION
[EVG-15787](EVG-15787)

I considered also including [GetVars(r)](https://github.com/evergreen-ci/gimlet/blob/bcf5586bf67539400214d4f562ed27040458aa61/parsing.go#L21) but I decided it wasn't worth adding to the message since we already have the path and the vars are part of the path.

I considered adding them to only one of the start and finish messages, but I figured both would be useful.

I considered checking the size of vars before logging it to make sure we're not logging to much to Splunk, but I think it's unlikely enough that we can wait and see if it's a problem.