### PR TITLE
EVG-16236 exclude the status route from recovery logger logging

### DIFF
--- a/middleware_grip.go
+++ b/middleware_grip.go
@@ -175,6 +175,11 @@ func MakeRecoveryLogger() Middleware {
 }
 
 func (l *appRecoveryLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if r.URL.Path == "/api/status/info" {
+		next(rw, r)
+		return
+	}
+
 	r = setupLogger(l.Journaler, r)
 	ctx := r.Context()
 


### PR DESCRIPTION
We want to exclude the status endpoint from the "started" and "completed" logging. 
Since the middleware is added to the entire negroni handler it's difficult to exclude a single route from it. Instead, I opted to make the middleware noop for this route.

I imagine the plan will be to include this in a custom build of evergreen and put the build up in staging.