### PR TITLE
EVG-19186 accept a configured router

### DIFF
--- a/app_merge.go
+++ b/app_merge.go
@@ -58,11 +58,16 @@ func AssembleHandler(router *mux.Router, apps ...*APIApp) (http.Handler, error) 
 
 // MergeApplications takes a number of gimlet applications and
 // resolves them, returning an http.Handler.
-func MergeApplications(router *mux.Router, apps ...*APIApp) (http.Handler, error) {
+func MergeApplications(apps ...*APIApp) (http.Handler, error) {
+	return MergeApplicationsWithRouter(nil, apps...)
+}
+
+// MergeApplicationsWithRouter takes a preconfigured router and
+// a number of gimlet applications and resolves them, returning an http.Handler.
+func MergeApplicationsWithRouter(router *mux.Router, apps ...*APIApp) (http.Handler, error) {
 	if len(apps) == 0 {
 		return nil, errors.New("must specify at least one application")
 	}
-
 	if router == nil {
 		router = mux.NewRouter().UseEncodedPath()
 	}

--- a/app_merge.go
+++ b/app_merge.go
@@ -58,12 +58,12 @@ func AssembleHandler(router *mux.Router, apps ...*APIApp) (http.Handler, error) 
 
 // MergeApplications takes a number of gimlet applications and
 // resolves them, returning an http.Handler.
-func MergeApplications(apps ...*APIApp) (http.Handler, error) {
+func MergeApplications(router *mux.Router, apps ...*APIApp) (http.Handler, error) {
 	if len(apps) == 0 {
 		return nil, errors.New("must specify at least one application")
 	}
 
-	return AssembleHandler(mux.NewRouter().UseEncodedPath(), apps...)
+	return AssembleHandler(router, apps...)
 }
 
 // Merge takes multiple application instances and merges all of their

--- a/app_merge.go
+++ b/app_merge.go
@@ -63,6 +63,10 @@ func MergeApplications(router *mux.Router, apps ...*APIApp) (http.Handler, error
 		return nil, errors.New("must specify at least one application")
 	}
 
+	if router == nil {
+		router = mux.NewRouter().UseEncodedPath()
+	}
+
 	return AssembleHandler(router, apps...)
 }
 

--- a/app_merge_test.go
+++ b/app_merge_test.go
@@ -69,6 +69,11 @@ func TestMergeAppsIntoRoute(t *testing.T) {
 	h, err = MergeApplications(router, bad, app)
 	assert.Error(t, err)
 	assert.Nil(t, h)
+
+	// nil router makes its own
+	h, err = MergeApplications(nil, app)
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
 }
 
 func TestMergeApps(t *testing.T) {

--- a/app_merge_test.go
+++ b/app_merge_test.go
@@ -41,8 +41,10 @@ func TestAssembleHandler(t *testing.T) {
 }
 
 func TestMergeAppsIntoRoute(t *testing.T) {
+	router := mux.NewRouter()
+
 	// error when no apps
-	h, err := MergeApplications()
+	h, err := MergeApplications(router)
 	assert.Error(t, err)
 	assert.Nil(t, h)
 
@@ -51,7 +53,7 @@ func TestMergeAppsIntoRoute(t *testing.T) {
 	app.SetPrefix("foo")
 	app.AddMiddleware(MakeRecoveryLogger())
 
-	h, err = MergeApplications(app)
+	h, err = MergeApplications(router, app)
 	assert.NoError(t, err)
 	assert.NotNil(t, h)
 
@@ -59,12 +61,12 @@ func TestMergeAppsIntoRoute(t *testing.T) {
 	bad := NewApp()
 	bad.AddRoute("/foo").version = -1
 
-	h, err = MergeApplications(bad)
+	h, err = MergeApplications(router, bad)
 	assert.Error(t, err)
 	assert.Nil(t, h)
 
 	// even when it's combined with a good one
-	h, err = MergeApplications(bad, app)
+	h, err = MergeApplications(router, bad, app)
 	assert.Error(t, err)
 	assert.Nil(t, h)
 }

--- a/app_merge_test.go
+++ b/app_merge_test.go
@@ -67,11 +67,6 @@ func TestMergeAppsIntoRoute(t *testing.T) {
 	h, err = MergeApplications(bad, app)
 	assert.Error(t, err)
 	assert.Nil(t, h)
-
-	// nil router makes its own
-	h, err = MergeApplications(nil, app)
-	assert.NoError(t, err)
-	assert.NotNil(t, h)
 }
 
 func TestMergeApps(t *testing.T) {

--- a/app_merge_test.go
+++ b/app_merge_test.go
@@ -41,10 +41,8 @@ func TestAssembleHandler(t *testing.T) {
 }
 
 func TestMergeAppsIntoRoute(t *testing.T) {
-	router := mux.NewRouter()
-
 	// error when no apps
-	h, err := MergeApplications(router)
+	h, err := MergeApplications()
 	assert.Error(t, err)
 	assert.Nil(t, h)
 
@@ -53,7 +51,7 @@ func TestMergeAppsIntoRoute(t *testing.T) {
 	app.SetPrefix("foo")
 	app.AddMiddleware(MakeRecoveryLogger())
 
-	h, err = MergeApplications(router, app)
+	h, err = MergeApplications(app)
 	assert.NoError(t, err)
 	assert.NotNil(t, h)
 
@@ -61,12 +59,12 @@ func TestMergeAppsIntoRoute(t *testing.T) {
 	bad := NewApp()
 	bad.AddRoute("/foo").version = -1
 
-	h, err = MergeApplications(router, bad)
+	h, err = MergeApplications(bad)
 	assert.Error(t, err)
 	assert.Nil(t, h)
 
 	// even when it's combined with a good one
-	h, err = MergeApplications(router, bad, app)
+	h, err = MergeApplications(bad, app)
 	assert.Error(t, err)
 	assert.Nil(t, h)
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/phyber/negroni-gzip v0.0.0-20180113114010-ef6356a5d029
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.8.3
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 	go.mongodb.org/mongo-driver v1.11.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -24,6 +24,7 @@ require (
 	github.com/dghubble/oauth1 v0.7.0 // indirect
 	github.com/fuyufjh/splunk-hec-go v0.3.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-github v17.0.0+incompatible // indirect
 	github.com/mattn/go-xmpp v0.0.0-20210723025538-3871461df959 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,9 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 h1:zLTLjkaOFEFIOxY5BWLFLwh+cL8vOBW4XJ2aqLE/Tf0=
@@ -202,8 +203,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
@@ -412,7 +413,6 @@ golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=


### PR DESCRIPTION
[EVG-19186](https://jira.mongodb.org/browse/EVG-19186)

Modify the `MergeApplications` function to take a preconfigured router. I want to be able to pass in a router with the OTEL instrumentation added. I don't think we'll necessarily want the tracer for every application that uses gimlet 😄, although it just noops if the tracer isn't configured.