### PR TITLE
DEVPROD-6570 Grip error on >500 codes

### DIFF
--- a/framework.go
+++ b/framework.go
@@ -81,7 +81,7 @@ func handleHandler(h RouteHandler) http.HandlerFunc {
 			if len(r.URL.Query()) > 0 {
 				m["params"] = r.URL.Query()
 			}
-			grip.Error(m)
+			grip.Debug(m)
 		}
 		WriteResponse(w, resp)
 	}


### PR DESCRIPTION
### Description

This automatically logs the response body of all 500+ status code requests, which allows us to inspect the error message directly in Splunk

### Testing

Hardcoded a route to return an internal service error and confirmed the error message was in Splunk

<img width="1009" alt="image" src="https://github.com/evergreen-ci/gimlet/assets/19805673/84063895-3ce4-4853-b127-54396c9b4efb">
