### PR TITLE
DEVPROD-11549 validate JWTs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/evergreen-ci/gimlet
 go 1.20
 
 require (
+	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035
 	github.com/evergreen-ci/utility v0.0.0-20230616220713-1332f9621270
 	github.com/go-ldap/ldap/v3 v3.4.4
@@ -64,6 +65,7 @@ require (
 	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/pquerna/cachecontrol v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.5 // indirect
@@ -91,5 +93,6 @@ require (
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7N
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
+github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
+github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -137,6 +139,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/pquerna/cachecontrol v0.2.0 h1:vBXSNuE5MYP9IJ5kjsdo8uq+w41jSPgvba2DEnkRx9k=
+github.com/pquerna/cachecontrol v0.2.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQnrHV5K9mBcUI=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
@@ -265,6 +269,8 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
+gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -255,7 +255,7 @@ func (u *userMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next
 func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, header string) (User, error) {
 	token, err := u.oidcVerifier.Verify(ctx, header)
 	if err != nil {
-		return nil, errors.Wrap(err, "got invalid jwt")
+		return nil, errors.Wrap(err, "verifying jwt")
 	}
 
 	claims := struct {

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -41,6 +41,10 @@ type OIDCConfig struct {
 }
 
 func (o *OIDCConfig) validate() error {
+	if o == nil {
+		return nil
+	}
+
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(o.HeaderName == "", "header name must be provided")
 	catcher.NewWhen(o.Issuer == "", "issuer must be provided")

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-oidc"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -19,10 +20,24 @@ type UserMiddlewareConfiguration struct {
 	SkipHeaderCheck bool
 	HeaderUserName  string
 	HeaderKeyName   string
+	OIDC            *OIDCConfig
 	CookieName      string
 	CookiePath      string
 	CookieTTL       time.Duration
 	CookieDomain    string
+}
+
+// OIDCConfig configures the validation of JWTs provided as a header on requests.
+type OIDCConfig struct {
+	// HeaderName is the name of the header expected to contain the JWT.
+	HeaderName string
+	// Issuer is the expected issuer of the JWT.
+	Issuer string
+	// KeysetURL is a URL to download a remote keyset from to use for validating the JWT.
+	KeysetURL string
+	// DisplayNameFromID parses a display name from the subject in the JWT. If not provided the
+	// display name will default to the token's subject.
+	DisplayNameFromID func(string) string
 }
 
 // Validate ensures that the UserMiddlewareConfiguration is correct
@@ -101,18 +116,29 @@ func GetUser(ctx context.Context) User {
 }
 
 type userMiddleware struct {
-	conf    UserMiddlewareConfiguration
-	manager UserManager
+	conf         UserMiddlewareConfiguration
+	manager      UserManager
+	oidcVerifier *oidc.IDTokenVerifier
 }
 
 // UserMiddleware produces a middleware that parses requests and uses
 // the UserManager attached to the request to find and attach a user
 // to the request.
-func UserMiddleware(um UserManager, conf UserMiddlewareConfiguration) Middleware {
-	return &userMiddleware{
+func UserMiddleware(ctx context.Context, um UserManager, conf UserMiddlewareConfiguration) (Middleware, error) {
+	middleware := &userMiddleware{
 		conf:    conf,
 		manager: um,
 	}
+
+	if conf.OIDC != nil {
+		middleware.oidcVerifier = oidc.NewVerifier(
+			conf.OIDC.Issuer,
+			oidc.NewRemoteKeySet(ctx, conf.OIDC.KeysetURL),
+			&oidc.Config{SkipClientIDCheck: true},
+		)
+	}
+
+	return middleware, nil
 }
 
 var ErrNeedsReauthentication = errors.New("user session has expired so they must be reauthenticated")
@@ -195,5 +221,48 @@ func (u *userMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next
 		}
 	}
 
+	if u.oidcVerifier != nil {
+		if jwt, ok := r.Header[u.conf.OIDC.HeaderName]; ok && len(jwt) > 0 {
+			usr, err := u.getUserForOIDCHeader(ctx, jwt[0])
+			logger.DebugWhen(err != nil, message.WrapError(err, message.Fields{
+				"message": "getting user for OIDC header",
+				"request": reqID,
+			}))
+			if err == nil && usr != nil {
+				r = setUserForRequest(r, usr)
+			}
+		}
+	}
+
 	next(rw, r)
+}
+
+func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, header string) (User, error) {
+	token, err := u.oidcVerifier.Verify(ctx, header)
+	if err != nil {
+		return nil, errors.Wrap(err, "got invalid jwt")
+	}
+
+	claims := struct {
+		Email string `json:"email"`
+	}{}
+	if err := token.Claims(&claims); err != nil {
+		return nil, errors.Wrap(err, "parsing token claims")
+	}
+
+	displayName := token.Subject
+	if u.conf.OIDC.DisplayNameFromID != nil {
+		displayName = u.conf.OIDC.DisplayNameFromID(token.Subject)
+	}
+
+	usr, err := u.manager.GetOrCreateUser(NewBasicUser(BasicUserOptions{
+		id:    token.Subject,
+		name:  displayName,
+		email: claims.Email,
+	}))
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating user '%s'", usr.Username())
+	}
+
+	return usr, nil
 }

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -124,7 +124,7 @@ type userMiddleware struct {
 // UserMiddleware produces a middleware that parses requests and uses
 // the UserManager attached to the request to find and attach a user
 // to the request.
-func UserMiddleware(ctx context.Context, um UserManager, conf UserMiddlewareConfiguration) (Middleware, error) {
+func UserMiddleware(ctx context.Context, um UserManager, conf UserMiddlewareConfiguration) Middleware {
 	middleware := &userMiddleware{
 		conf:    conf,
 		manager: um,
@@ -138,7 +138,7 @@ func UserMiddleware(ctx context.Context, um UserManager, conf UserMiddlewareConf
 		)
 	}
 
-	return middleware, nil
+	return middleware
 }
 
 var ErrNeedsReauthentication = errors.New("user session has expired so they must be reauthenticated")

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -237,8 +237,8 @@ func (u *userMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next
 	}
 
 	if u.oidcVerifier != nil {
-		if jwt, ok := r.Header[u.conf.OIDC.HeaderName]; ok && len(jwt) > 0 {
-			usr, err := u.getUserForOIDCHeader(ctx, jwt[0])
+		if jwt := r.Header.Get(u.conf.OIDC.HeaderName); len(jwt) > 0 {
+			usr, err := u.getUserForOIDCHeader(ctx, jwt)
 			logger.DebugWhen(err != nil, message.WrapError(err, message.Fields{
 				"message": "getting user for OIDC header",
 				"request": reqID,

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -40,6 +40,15 @@ type OIDCConfig struct {
 	DisplayNameFromID func(string) string
 }
 
+func (o *OIDCConfig) validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(o.HeaderName == "", "header name must be provided")
+	catcher.NewWhen(o.Issuer == "", "issuer must be provided")
+	catcher.NewWhen(o.KeysetURL == "", "keyset URL must be provided")
+
+	return catcher.Resolve()
+}
+
 // Validate ensures that the UserMiddlewareConfiguration is correct
 // and internally consistent.
 func (umc *UserMiddlewareConfiguration) Validate() error {
@@ -60,6 +69,8 @@ func (umc *UserMiddlewareConfiguration) Validate() error {
 		catcher.NewWhen(umc.HeaderUserName == "", "must specify a header user name when header auth is enabled")
 		catcher.NewWhen(umc.HeaderKeyName == "", "must specify a header key name when header auth is enabled")
 	}
+
+	catcher.AddWhen(umc.OIDC != nil, umc.OIDC.validate())
 
 	return catcher.Resolve()
 }

--- a/middleware_auth_user_test.go
+++ b/middleware_auth_user_test.go
@@ -28,7 +28,7 @@ func TestUserMiddleware(t *testing.T) {
 	for name, testCase := range map[string]func(*testing.T){
 		"Constructor": func(t *testing.T) {
 			m := UserMiddleware(ctx, um, UserMiddlewareConfiguration{})
-			assert.NotNil(t, m)
+			require.NotNil(t, m)
 			assert.Implements(t, (*Middleware)(nil), m)
 			assert.Implements(t, (*negroni.Handler)(nil), m)
 			assert.Equal(t, m.(*userMiddleware).conf, UserMiddlewareConfiguration{})
@@ -36,7 +36,7 @@ func TestUserMiddleware(t *testing.T) {
 		},
 		"NothingEnabled": func(t *testing.T) {
 			m := UserMiddleware(ctx, um, UserMiddlewareConfiguration{SkipHeaderCheck: true, SkipCookie: true})
-			assert.NotNil(t, m)
+			require.NotNil(t, m)
 			req := httptest.NewRequest("GET", "http://localhost/bar", nil)
 			rw := httptest.NewRecorder()
 
@@ -56,7 +56,7 @@ func TestUserMiddleware(t *testing.T) {
 				{SkipHeaderCheck: false, SkipCookie: false},
 			} {
 				m := UserMiddleware(ctx, um, conf)
-				assert.NotNil(t, m)
+				require.NotNil(t, m)
 				req := httptest.NewRequest("GET", "http://localhost/bar", nil)
 				rw := httptest.NewRecorder()
 				next := func(rw http.ResponseWriter, r *http.Request) {
@@ -78,7 +78,7 @@ func TestUserMiddleware(t *testing.T) {
 				HeaderKeyName:   "api-key",
 			}
 			m := UserMiddleware(ctx, um, conf)
-			assert.NotNil(t, m)
+			require.NotNil(t, m)
 
 			req := httptest.NewRequest("GET", "http://localhost/bar", nil)
 			req.Header[conf.HeaderUserName] = []string{user.ID}
@@ -98,7 +98,7 @@ func TestUserMiddleware(t *testing.T) {
 				HeaderKeyName:   "api-key",
 			}
 			m := UserMiddleware(ctx, um, conf)
-			assert.NotNil(t, m)
+			require.NotNil(t, m)
 
 			req := httptest.NewRequest("GET", "http://localhost/bar", nil)
 			req.Header[conf.HeaderUserName] = []string{user.ID}
@@ -119,9 +119,8 @@ func TestUserMiddleware(t *testing.T) {
 			}
 			m := UserMiddleware(ctx, um, conf)
 
-			req, err := http.NewRequest("GET", "http://localhost/bar", nil)
-			assert.NoError(t, err)
-			assert.NotNil(t, req)
+			req := httptest.NewRequest("GET", "http://localhost/bar", nil)
+			require.NotNil(t, req)
 			req.AddCookie(&http.Cookie{
 				Name:  conf.CookieName,
 				Value: user.Token,
@@ -141,8 +140,7 @@ func TestUserMiddleware(t *testing.T) {
 			}
 			m := UserMiddleware(ctx, um, conf)
 
-			req, err := http.NewRequest("GET", "http://localhost/bar", nil)
-			assert.NoError(t, err)
+			req := httptest.NewRequest("GET", "http://localhost/bar", nil)
 			req.AddCookie(&http.Cookie{
 				Name:  "foo",
 				Value: "DEADBEEF",
@@ -162,9 +160,8 @@ func TestUserMiddleware(t *testing.T) {
 			}
 			m := UserMiddleware(ctx, um, conf)
 
-			req, err := http.NewRequest("GET", "http://localhost/bar", nil)
-			assert.NoError(t, err)
-			assert.NotNil(t, req)
+			req := httptest.NewRequest("GET", "http://localhost/bar", nil)
+			require.NotNil(t, req)
 			req.AddCookie(&http.Cookie{
 				Name:  "gimlet-token",
 				Value: "DEADC0DE",
@@ -185,9 +182,8 @@ func TestUserMiddleware(t *testing.T) {
 			}
 			m := UserMiddleware(ctx, um, conf)
 
-			req, err := http.NewRequest("GET", "http://localhost/bar", nil)
-			assert.NoError(t, err)
-			assert.NotNil(t, req)
+			req := httptest.NewRequest("GET", "http://localhost/bar", nil)
+			require.NotNil(t, req)
 			req.AddCookie(&http.Cookie{
 				Name:  conf.CookieName,
 				Value: user.Token,
@@ -244,9 +240,8 @@ func TestOIDCValidation(t *testing.T) {
 	)
 
 	t.Run("ValidJWT", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "http://localhost/bar", nil)
-		assert.NoError(t, err)
-		assert.NotNil(t, req)
+		req := httptest.NewRequest("GET", "http://localhost/bar", nil)
+		require.NotNil(t, req)
 		req.Header.Add(headerName, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJpLWFtLXNhbSIsImlhdCI6MTcyNzIwODMzNywiaXNzIjoid3d3Lm1vbmdvZGIuY29tIn0.RpKLMhvXe6IISKzmwLbVT6trddAy37_7A4Dmq_SSeh0")
 		rw := httptest.NewRecorder()
 		m.ServeHTTP(rw, req, func(rw http.ResponseWriter, r *http.Request) {
@@ -257,9 +252,8 @@ func TestOIDCValidation(t *testing.T) {
 	})
 
 	t.Run("HeaderMissing", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "http://localhost/bar", nil)
-		assert.NoError(t, err)
-		assert.NotNil(t, req)
+		req := httptest.NewRequest("GET", "http://localhost/bar", nil)
+		require.NotNil(t, req)
 		rw := httptest.NewRecorder()
 		m.ServeHTTP(rw, req, func(rw http.ResponseWriter, r *http.Request) {
 			rusr := GetUser(r.Context())
@@ -269,9 +263,8 @@ func TestOIDCValidation(t *testing.T) {
 	})
 
 	t.Run("InvalidJWT", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "http://localhost/bar", nil)
-		assert.NoError(t, err)
-		assert.NotNil(t, req)
+		req := httptest.NewRequest("GET", "http://localhost/bar", nil)
+		require.NotNil(t, req)
 		req.Header.Add(headerName, "not_a_valid_jwt")
 		rw := httptest.NewRecorder()
 		m.ServeHTTP(rw, req, func(rw http.ResponseWriter, r *http.Request) {

--- a/middleware_auth_user_test.go
+++ b/middleware_auth_user_test.go
@@ -181,6 +181,11 @@ func TestUserMiddlewareConfiguration(t *testing.T) {
 		CookieName:     "c",
 		CookieTTL:      time.Hour,
 		CookiePath:     "/p",
+		OIDC: &OIDCConfig{
+			HeaderName: "internal_header",
+			KeysetURL:  "www.example.com",
+			Issuer:     "www.google.com",
+		},
 	}
 	require.NoError(t, conf.Validate())
 
@@ -206,6 +211,17 @@ func TestUserMiddlewareConfiguration(t *testing.T) {
 		assert.Len(t, rw.Header(), 1)
 		conf.ClearCookie(rw)
 		assert.Len(t, rw.Header(), 1)
+	})
+
+	t.Run("NilOIDC", func(t *testing.T) {
+		conf := UserMiddlewareConfiguration{
+			HeaderUserName: "u",
+			HeaderKeyName:  "k",
+			CookieName:     "c",
+			CookieTTL:      time.Hour,
+			CookiePath:     "/p",
+		}
+		assert.NoError(t, conf.Validate())
 	})
 
 	t.Run("InvalidConfigurations", func(t *testing.T) {
@@ -248,6 +264,27 @@ func TestUserMiddlewareConfiguration(t *testing.T) {
 					return conf
 				},
 			},
+			{
+				name: "MissingOIDCHeaderName",
+				op: func(conf UserMiddlewareConfiguration) UserMiddlewareConfiguration {
+					conf.OIDC.HeaderName = ""
+					return conf
+				},
+			},
+			{
+				name: "MissingOIDCKeysetURL",
+				op: func(conf UserMiddlewareConfiguration) UserMiddlewareConfiguration {
+					conf.OIDC.KeysetURL = ""
+					return conf
+				},
+			},
+			{
+				name: "MissingOIDCIssuer",
+				op: func(conf UserMiddlewareConfiguration) UserMiddlewareConfiguration {
+					conf.OIDC.Issuer = ""
+					return conf
+				},
+			},
 		} {
 			t.Run(test.name, func(t *testing.T) {
 				conf := UserMiddlewareConfiguration{
@@ -256,6 +293,11 @@ func TestUserMiddlewareConfiguration(t *testing.T) {
 					CookieName:     "c",
 					CookieTTL:      time.Hour,
 					CookiePath:     "/p",
+					OIDC: &OIDCConfig{
+						HeaderName: "internal_header",
+						KeysetURL:  "www.example.com",
+						Issuer:     "www.google.com",
+					},
 				}
 				require.NoError(t, conf.Validate())
 				conf = test.op(conf)


### PR DESCRIPTION
[DEVPROD-11549](https://jira.mongodb.org/browse/DEVPROD-11549)

This PR allows fetching a user by their JWT. This will be used in a forthcoming PR on Evergreen.
The go-oidc library is the one Kanopy uses internally, though we can't use v3 on go 1.20.