### PR TITLE
DEVPROD-14866 Return full error rather than unwrapped cause error

### DIFF
--- a/framework_response_simple.go
+++ b/framework_response_simple.go
@@ -26,7 +26,7 @@ func newResponder(data interface{}, code int, of OutputFormat) Responder {
 		default:
 			eresp = ErrorResponse{
 				StatusCode: code,
-				Message:    err.Error(),
+				Message:    in.Error(),
 			}
 		}
 


### PR DESCRIPTION
DEVPROD-14866

When we were returning err.Error, that's just the cause. Returning in.Error will return the full context of the error (all information possible)