### PR TITLE
DEVPROD-16231 Filter for Spiffe Subject 

### DIFF
--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -252,6 +252,9 @@ func (u *userMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next
 	next(rw, r)
 }
 
+const unauthorizedSpifeServiceUser = "Istio-Ingressgateway-Public-Service-Account"
+const spiffeRoute = "spiffe://cluster.local/ns/routing"
+
 func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, header string) (User, error) {
 	token, err := u.oidcVerifier.Verify(ctx, header)
 	if err != nil {
@@ -263,6 +266,14 @@ func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, header string
 	}{}
 	if err := token.Claims(&claims); err != nil {
 		return nil, errors.Wrap(err, "parsing token claims")
+	}
+	// if the subject starts with the spiffe route, then
+	// ignore it if it's the unauthorized user.
+	if strings.HasPrefix(token.Subject, spiffeRoute) {
+		// Istio-Ingressgateway-Public-Service-Account
+		if strings.Contains(token.Subject, unauthorizedSpifeServiceUser) {
+			return nil, errors.New("unauthorized user")
+		}
 	}
 
 	displayName := token.Subject


### PR DESCRIPTION
DEVPROD-16231

### Description
Before Kanopy started supporting service users, if a request didn't go through corpsecure, the header wasn’t set and we were able to default to our own auth. After Kanopy started supporting service users, the header gets set with an un-authed users. This causes issues for our non ".corp" routes. This puts us back to our original setup of ignoring users who are not authed through corpsecure and attempting to auth them through our own auth. This will help us maintain backwards compatibility as we transition. 