### PR TITLE
DEVPROD-16412: append attributes rather than overwrite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035
-	github.com/evergreen-ci/utility v0.0.0-20250224222128-c2a9c8dfbc87
+	github.com/evergreen-ci/utility v0.0.0-20250604173729-c1b32de37d48
 	github.com/go-ldap/ldap/v3 v3.4.4
 	github.com/gorilla/mux v1.8.0
 	github.com/mongodb/grip v0.0.0-20250224221724-fc8adcb1fe8e

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/dghubble/oauth1 v0.7.2/go.mod h1:9erQdIhqhOHG/7K9s/tgh9Ks/AfoyrO5mW/4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/sRq+GAogUMLa7LBGtvVHMVLbisuytxBC5KaY=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
-github.com/evergreen-ci/utility v0.0.0-20250224222128-c2a9c8dfbc87 h1:cBuYKFje/Y089ab5Rm6TaFYhzcFWZOjCIOyIAgfGihs=
-github.com/evergreen-ci/utility v0.0.0-20250224222128-c2a9c8dfbc87/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
+github.com/evergreen-ci/utility v0.0.0-20250604173729-c1b32de37d48 h1:xvB8GHNdC6wMsReqxNdmtlA8JU+hanPxHcDZ0wdkTTM=
+github.com/evergreen-ci/utility v0.0.0-20250604173729-c1b32de37d48/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -109,7 +109,7 @@ func setUserForRequest(r *http.Request, u User) *http.Request {
 	userID := u.Username()
 	AddLoggingAnnotation(r, "user", userID)
 	ctx := r.Context()
-	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{
+	ctx = utility.ContextWithAppendedAttributes(ctx, []attribute.KeyValue{
 		attribute.String(userIDAttribute, userID),
 	})
 	ctx = AttachUser(ctx, u)

--- a/middleware_grip.go
+++ b/middleware_grip.go
@@ -118,7 +118,7 @@ func setupLogger(logger grip.Journaler, r *http.Request) *http.Request {
 
 	id := getNumber()
 	r = setRequestID(r, id)
-	r = r.WithContext(utility.ContextWithAttributes(r.Context(), []attribute.KeyValue{attribute.Int(requestIDAttribute, id)}))
+	r = r.WithContext(utility.ContextWithAppendedAttributes(r.Context(), []attribute.KeyValue{attribute.Int(requestIDAttribute, id)}))
 
 	startAt := time.Now()
 	r = setStartAtTime(r, startAt)


### PR DESCRIPTION
DEVPROD-16412

Follow-up to #180 - instead of using `ContextWithAttributes`, which overwrites all existing attributes, append attributes instead.