### PR TITLE
DEVPROD-31775 Allow for multiple OIDC validations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035
 	github.com/evergreen-ci/utility v0.0.0-20251203163234-8a1c0ea8b717
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/mongodb/grip v0.0.0-20260325175240-dee15316ed15
 	github.com/okta/okta-jwt-verifier-golang/v2 v2.1.1
@@ -37,7 +38,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-github/v79 v79.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -9,10 +9,15 @@ import (
 
 	"github.com/coreos/go-oidc"
 	"github.com/evergreen-ci/utility"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	oidcKeyDelimiter = "\x00"
 )
 
 // UserMiddlewareConfiguration is an keyed-arguments struct used to
@@ -22,7 +27,7 @@ type UserMiddlewareConfiguration struct {
 	SkipHeaderCheck bool
 	HeaderUserName  string
 	HeaderKeyName   string
-	OIDC            *OIDCConfig
+	OIDCConfigs     []*OIDCConfig
 	CookieName      string
 	CookiePath      string
 	CookieTTL       time.Duration
@@ -80,7 +85,9 @@ func (umc *UserMiddlewareConfiguration) Validate() error {
 		catcher.NewWhen(umc.HeaderKeyName == "", "must specify a header key name when header auth is enabled")
 	}
 
-	catcher.AddWhen(umc.OIDC != nil, umc.OIDC.validate())
+	for _, c := range umc.OIDCConfigs {
+		catcher.AddWhen(c != nil, c.validate())
+	}
 
 	return catcher.Resolve()
 }
@@ -142,10 +149,16 @@ func GetUser(ctx context.Context) User {
 	return usr
 }
 
+type oidcVerifierPair struct {
+	config   *OIDCConfig
+	verifier *oidc.IDTokenVerifier
+}
+
 type userMiddleware struct {
-	conf         UserMiddlewareConfiguration
-	manager      UserManager
-	oidcVerifier *oidc.IDTokenVerifier
+	conf    UserMiddlewareConfiguration
+	manager UserManager
+	// oidcKeyToVerifierPair maps a key (header name + issuer) to a verifier pair.
+	oidcKeyToVerifierPair map[string]*oidcVerifierPair
 }
 
 // UserMiddleware produces a middleware that parses requests and uses
@@ -157,12 +170,23 @@ func UserMiddleware(ctx context.Context, um UserManager, conf UserMiddlewareConf
 		manager: um,
 	}
 
-	if conf.OIDC != nil {
-		middleware.oidcVerifier = oidc.NewVerifier(
-			conf.OIDC.Issuer,
-			oidc.NewRemoteKeySet(ctx, conf.OIDC.KeysetURL),
+	for _, cfg := range conf.OIDCConfigs {
+		if cfg == nil {
+			continue
+		}
+		if middleware.oidcKeyToVerifierPair == nil {
+			middleware.oidcKeyToVerifierPair = make(map[string]*oidcVerifierPair)
+		}
+		key := oidcKey(cfg.HeaderName, cfg.Issuer)
+		verifier := oidc.NewVerifier(
+			cfg.Issuer,
+			oidc.NewRemoteKeySet(ctx, cfg.KeysetURL),
 			&oidc.Config{SkipClientIDCheck: true},
 		)
+		middleware.oidcKeyToVerifierPair[key] = &oidcVerifierPair{
+			config:   cfg,
+			verifier: verifier,
+		}
 	}
 
 	return middleware
@@ -254,16 +278,24 @@ func (u *userMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next
 		}
 	}
 
-	if u.oidcVerifier != nil {
-		if jwt := r.Header.Get(u.conf.OIDC.HeaderName); len(jwt) > 0 {
-			usr, err := u.getUserForOIDCHeader(ctx, jwt)
-			logger.DebugWhen(ctx, err != nil, message.WrapError(err, message.Fields{
-				"message": "getting user for OIDC header",
-				"request": reqID,
-			}))
-			if err == nil && usr != nil {
-				r = setUserForRequest(r, usr)
-			}
+	for key, pair := range u.oidcKeyToVerifierPair {
+		header, issuer := splitOidcKey(key)
+		jwt := r.Header.Get(header)
+		if len(jwt) == 0 {
+			continue
+		}
+		receivedIssuer, err := parseUnverifiedIssuer(jwt)
+		if err != nil || receivedIssuer == "" || issuer != receivedIssuer {
+			continue
+		}
+		usr, err := u.getUserForOIDCHeader(ctx, jwt, pair)
+		logger.DebugWhen(ctx, err != nil, message.WrapError(err, message.Fields{
+			"message": "getting user for OIDC header",
+			"request": reqID,
+		}))
+		if err == nil && usr != nil {
+			r = setUserForRequest(r, usr)
+			break
 		}
 	}
 
@@ -278,8 +310,25 @@ func (u *userMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next
 const unauthorizedSpifeServiceUser = "istio-ingressgateway-public-service-account"
 const spiffeRoute = "spiffe://cluster.local/ns/routing"
 
-func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, header string) (User, error) {
-	token, err := u.oidcVerifier.Verify(ctx, header)
+func parseUnverifiedIssuer(raw string) (string, error) {
+	raw = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(raw), "Bearer "))
+	if raw == "" {
+		return "", errors.New("empty JWT")
+	}
+	token, _, err := jwt.NewParser().ParseUnverified(raw, jwt.MapClaims{})
+	if err != nil {
+		return "", err
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", errors.New("invalid JWT claims")
+	}
+	iss, _ := claims["iss"].(string)
+	return iss, nil
+}
+
+func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, jwt string, pair *oidcVerifierPair) (User, error) {
+	token, err := pair.verifier.Verify(ctx, jwt)
 	if err != nil {
 		return nil, errors.Wrap(err, "verifying jwt")
 	}
@@ -299,8 +348,9 @@ func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, header string
 	}
 
 	displayName := token.Subject
-	if u.conf.OIDC.DisplayNameFromID != nil {
-		displayName = u.conf.OIDC.DisplayNameFromID(token.Subject)
+	// TODO: implement this
+	if pair.config.DisplayNameFromID != nil {
+		displayName = pair.config.DisplayNameFromID(token.Subject)
 	}
 
 	usr, err := u.manager.GetOrCreateUser(ctx, NewBasicUser(BasicUserOptions{
@@ -313,4 +363,13 @@ func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, header string
 	}
 
 	return usr, nil
+}
+
+func oidcKey(headerName, issuer string) string {
+	return headerName + oidcKeyDelimiter + issuer
+}
+
+func splitOidcKey(key string) (string, string) {
+	parts := strings.SplitN(key, oidcKeyDelimiter, 2)
+	return parts[0], parts[1]
 }

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -166,23 +166,21 @@ type userMiddleware struct {
 // to the request.
 func UserMiddleware(ctx context.Context, um UserManager, conf UserMiddlewareConfiguration) Middleware {
 	middleware := &userMiddleware{
-		conf:    conf,
-		manager: um,
+		conf:                  conf,
+		manager:               um,
+		oidcKeyToVerifierPair: make(map[string]*oidcVerifierPair),
 	}
 
 	for _, cfg := range conf.OIDCConfigs {
 		if cfg == nil {
 			continue
 		}
-		if middleware.oidcKeyToVerifierPair == nil {
-			middleware.oidcKeyToVerifierPair = make(map[string]*oidcVerifierPair)
-		}
-		key := oidcKey(cfg.HeaderName, cfg.Issuer)
 		verifier := oidc.NewVerifier(
 			cfg.Issuer,
 			oidc.NewRemoteKeySet(ctx, cfg.KeysetURL),
 			&oidc.Config{SkipClientIDCheck: true},
 		)
+		key := oidcKey(cfg.HeaderName, cfg.Issuer)
 		middleware.oidcKeyToVerifierPair[key] = &oidcVerifierPair{
 			config:   cfg,
 			verifier: verifier,

--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -346,7 +346,6 @@ func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, jwt string, p
 	}
 
 	displayName := token.Subject
-	// TODO: implement this
 	if pair.config.DisplayNameFromID != nil {
 		displayName = pair.config.DisplayNameFromID(token.Subject)
 	}

--- a/middleware_auth_user_test.go
+++ b/middleware_auth_user_test.go
@@ -2,13 +2,16 @@ package gimlet
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/coreos/go-oidc"
 	"github.com/evergreen-ci/negroni"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -277,9 +280,11 @@ func TestUserMiddleware(t *testing.T) {
 type mockKeyset struct {
 	validSignature bool
 	payload        string
+	verifyCalls    int
 }
 
 func (k *mockKeyset) VerifySignature(ctx context.Context, jwt string) (payload []byte, err error) {
+	k.verifyCalls++
 	if !k.validSignature {
 		return nil, errors.New("invalid signature")
 	}
@@ -287,59 +292,99 @@ func (k *mockKeyset) VerifySignature(ctx context.Context, jwt string) (payload [
 }
 
 func TestOIDCValidation(t *testing.T) {
+	headerName := "internal_header"
 	user := &MockUser{ID: "i-am-sam"}
 	um := &MockUserManager{Users: []*MockUser{user}}
-	headerName := "internal_header"
-	conf := UserMiddlewareConfiguration{
-		SkipHeaderCheck: true,
-		SkipCookie:      true,
-		OIDC: &OIDCConfig{
-			HeaderName: headerName,
-			Issuer:     "www.mongodb.com",
-		},
-	}
-
-	payload := `{"sub":"i-am-sam","iat":1727208337,"iss":"www.mongodb.com"}`
-	m := UserMiddleware(t.Context(), um, conf).(*userMiddleware)
-	m.oidcVerifier = oidc.NewVerifier(
-		conf.OIDC.Issuer,
-		&mockKeyset{validSignature: true, payload: payload},
-		&oidc.Config{SkipClientIDCheck: true, SkipExpiryCheck: true, SupportedSigningAlgs: []string{"HS256"}},
-	)
 
 	t.Run("ValidJWT", func(t *testing.T) {
+		conf := UserMiddlewareConfiguration{
+			SkipHeaderCheck: true,
+			SkipCookie:      true,
+			OIDCConfigs: []*OIDCConfig{
+				{HeaderName: headerName, Issuer: "www.mongodb.com", KeysetURL: "http://example.com"},
+			},
+		}
+		payload := `{"sub":"i-am-sam","iat":1727208337,"iss":"www.mongodb.com"}`
+		m := UserMiddleware(t.Context(), um, conf).(*userMiddleware)
+		m.oidcKeyToVerifierPair[oidcKey(headerName, conf.OIDCConfigs[0].Issuer)].verifier = oidc.NewVerifier(
+			conf.OIDCConfigs[0].Issuer,
+			&mockKeyset{validSignature: true, payload: payload},
+			&oidc.Config{SkipClientIDCheck: true, SkipExpiryCheck: true, SupportedSigningAlgs: []string{"HS256"}},
+		)
 		req := httptest.NewRequest("GET", "http://localhost/bar", nil)
-		require.NotNil(t, req)
 		req.Header.Add(headerName, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJpLWFtLXNhbSIsImlhdCI6MTcyNzIwODMzNywiaXNzIjoid3d3Lm1vbmdvZGIuY29tIn0.RpKLMhvXe6IISKzmwLbVT6trddAy37_7A4Dmq_SSeh0")
 		rw := httptest.NewRecorder()
 		m.ServeHTTP(rw, req, func(rw http.ResponseWriter, r *http.Request) {
-			rusr := GetUser(r.Context())
-			assert.Equal(t, user.Username(), rusr.Username())
+			assert.Equal(t, user.Username(), GetUser(r.Context()).Username())
 		})
 		assert.Equal(t, http.StatusOK, rw.Code)
 	})
 
-	t.Run("HeaderMissing", func(t *testing.T) {
+	t.Run("IssuerRouting", func(t *testing.T) {
+		multiConf := UserMiddlewareConfiguration{
+			SkipHeaderCheck: true,
+			SkipCookie:      true,
+			OIDCConfigs: []*OIDCConfig{
+				{HeaderName: headerName, Issuer: "issuer-a", KeysetURL: "http://example.com/a"},
+				{HeaderName: headerName, Issuer: "issuer-b", KeysetURL: "http://example.com/b"},
+			},
+		}
+		require.NoError(t, multiConf.Validate())
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"sub": "i-am-sam",
+			"iat": float64(1727208337),
+			"iss": "issuer-b",
+		})
+		tokenString, err := token.SignedString([]byte("secret"))
+		require.NoError(t, err)
+		parts := strings.Split(tokenString, ".")
+		require.Len(t, parts, 3)
+		payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+		require.NoError(t, err)
+		payload := string(payloadBytes)
+		mMulti := UserMiddleware(t.Context(), um, multiConf).(*userMiddleware)
+		mMulti.oidcKeyToVerifierPair[oidcKey(headerName, "issuer-b")].verifier = oidc.NewVerifier(
+			"issuer-b",
+			&mockKeyset{validSignature: true, payload: payload},
+			&oidc.Config{SkipClientIDCheck: true, SkipExpiryCheck: true, SupportedSigningAlgs: []string{"HS256"}},
+		)
 		req := httptest.NewRequest("GET", "http://localhost/bar", nil)
-		require.NotNil(t, req)
+		req.Header.Add(headerName, tokenString)
 		rw := httptest.NewRecorder()
-		m.ServeHTTP(rw, req, func(rw http.ResponseWriter, r *http.Request) {
-			rusr := GetUser(r.Context())
-			assert.Nil(t, rusr)
+		mMulti.ServeHTTP(rw, req, func(rw http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, user.Username(), GetUser(r.Context()).Username())
 		})
 		assert.Equal(t, http.StatusOK, rw.Code)
-	})
 
-	t.Run("InvalidJWT", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "http://localhost/bar", nil)
-		require.NotNil(t, req)
-		req.Header.Add(headerName, "not_a_valid_jwt")
-		rw := httptest.NewRecorder()
-		m.ServeHTTP(rw, req, func(rw http.ResponseWriter, r *http.Request) {
-			rusr := GetUser(r.Context())
-			assert.Nil(t, rusr)
+		singleConf := UserMiddlewareConfiguration{
+			SkipHeaderCheck: true,
+			SkipCookie:      true,
+			OIDCConfigs: []*OIDCConfig{
+				{HeaderName: headerName, Issuer: "www.mongodb.com", KeysetURL: "http://example.com"},
+			},
+		}
+		ks := &mockKeyset{validSignature: true, payload: `{"sub":"i-am-sam","iss":"www.mongodb.com"}`}
+		mSingle := UserMiddleware(t.Context(), um, singleConf).(*userMiddleware)
+		mSingle.oidcKeyToVerifierPair[oidcKey(headerName, singleConf.OIDCConfigs[0].Issuer)].verifier = oidc.NewVerifier(
+			singleConf.OIDCConfigs[0].Issuer,
+			ks,
+			&oidc.Config{SkipClientIDCheck: true, SkipExpiryCheck: true, SupportedSigningAlgs: []string{"HS256"}},
+		)
+		badToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"sub": "i-am-sam",
+			"iat": float64(1727208337),
+			"iss": "unknown-issuer",
 		})
-		assert.Equal(t, http.StatusOK, rw.Code)
+		badTokenString, err := badToken.SignedString([]byte("secret"))
+		require.NoError(t, err)
+		req2 := httptest.NewRequest("GET", "http://localhost/bar", nil)
+		req2.Header.Add(headerName, badTokenString)
+		rw2 := httptest.NewRecorder()
+		mSingle.ServeHTTP(rw2, req2, func(rw http.ResponseWriter, r *http.Request) {
+			assert.Nil(t, GetUser(r.Context()))
+		})
+		assert.Equal(t, http.StatusOK, rw2.Code)
+		assert.Zero(t, ks.verifyCalls)
 	})
 }
 
@@ -350,10 +395,8 @@ func TestUserMiddlewareConfiguration(t *testing.T) {
 		CookieName:     "c",
 		CookieTTL:      time.Hour,
 		CookiePath:     "/p",
-		OIDC: &OIDCConfig{
-			HeaderName: "internal_header",
-			KeysetURL:  "www.example.com",
-			Issuer:     "www.google.com",
+		OIDCConfigs: []*OIDCConfig{
+			{HeaderName: "internal_header", KeysetURL: "www.example.com", Issuer: "www.google.com"},
 		},
 	}
 	require.NoError(t, conf.Validate())
@@ -380,17 +423,6 @@ func TestUserMiddlewareConfiguration(t *testing.T) {
 		assert.Len(t, rw.Header(), 1)
 		conf.ClearCookie(rw)
 		assert.Len(t, rw.Header(), 1)
-	})
-
-	t.Run("NilOIDC", func(t *testing.T) {
-		conf := UserMiddlewareConfiguration{
-			HeaderUserName: "u",
-			HeaderKeyName:  "k",
-			CookieName:     "c",
-			CookieTTL:      time.Hour,
-			CookiePath:     "/p",
-		}
-		assert.NoError(t, conf.Validate())
 	})
 
 	t.Run("InvalidConfigurations", func(t *testing.T) {
@@ -436,21 +468,21 @@ func TestUserMiddlewareConfiguration(t *testing.T) {
 			{
 				name: "MissingOIDCHeaderName",
 				op: func(conf UserMiddlewareConfiguration) UserMiddlewareConfiguration {
-					conf.OIDC.HeaderName = ""
+					conf.OIDCConfigs[0].HeaderName = ""
 					return conf
 				},
 			},
 			{
 				name: "MissingOIDCKeysetURL",
 				op: func(conf UserMiddlewareConfiguration) UserMiddlewareConfiguration {
-					conf.OIDC.KeysetURL = ""
+					conf.OIDCConfigs[0].KeysetURL = ""
 					return conf
 				},
 			},
 			{
 				name: "MissingOIDCIssuer",
 				op: func(conf UserMiddlewareConfiguration) UserMiddlewareConfiguration {
-					conf.OIDC.Issuer = ""
+					conf.OIDCConfigs[0].Issuer = ""
 					return conf
 				},
 			},
@@ -462,10 +494,8 @@ func TestUserMiddlewareConfiguration(t *testing.T) {
 					CookieName:     "c",
 					CookieTTL:      time.Hour,
 					CookiePath:     "/p",
-					OIDC: &OIDCConfig{
-						HeaderName: "internal_header",
-						KeysetURL:  "www.example.com",
-						Issuer:     "www.google.com",
+					OIDCConfigs: []*OIDCConfig{
+						{HeaderName: "internal_header", KeysetURL: "www.example.com", Issuer: "www.google.com"},
 					},
 				}
 				require.NoError(t, conf.Validate())


### PR DESCRIPTION
[DEVPROD-31775](https://jira.mongodb.org/browse/DEVPROD-31775)

### Description
Token exchange tokens (used for spawn hosts) do not authenticate as the user. The issuer is different so it gets rejected.

### Testing
Add unit tests