### PR TITLE
DEVPROD-31775 Load user data if the oidc token subject is their email

### DIFF
--- a/middleware_auth_user.go
+++ b/middleware_auth_user.go
@@ -351,10 +351,21 @@ func (u *userMiddleware) getUserForOIDCHeader(ctx context.Context, jwt string, c
 		displayName = config.DisplayNameFromID(token.Subject)
 	}
 
+	// Most tokens send the user's ID as the subject. Some tokens
+	// send their email as the subject, for those tokens, we send only
+	// the email to GetOrCreateUser.
+	email := claims.Email
+	id := token.Subject
+	if strings.Contains(token.Subject, "@") {
+		email = token.Subject
+		id = ""
+		displayName = ""
+	}
+
 	usr, err := u.manager.GetOrCreateUser(ctx, NewBasicUser(BasicUserOptions{
-		id:    token.Subject,
+		id:    id,
 		name:  displayName,
-		email: claims.Email,
+		email: email,
 	}))
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting or creating user '%s'", displayName)


### PR DESCRIPTION
[DEVPROD-31775]

### Description
We have different 'types' of tokens that need to auth in Evergreen. The spawn host token sends over the email as the subject (this cannot be changed, details on ticket). This PR parses this and accounts for it

### Testing
Deployed to staging, spawned a host, and it auth'ed me as me